### PR TITLE
doc: add hyperopt function to api page

### DIFF
--- a/src/code_doc_autogen.py
+++ b/src/code_doc_autogen.py
@@ -41,7 +41,7 @@ from ludwig.visualize import learning_curves, compare_performance, \
     confidence_thresholding_data_vs_acc_subset, binary_threshold_vs_metric, \
     roc_curves, roc_curves_from_test_statistics, calibration_1_vs_all, \
     calibration_multiclass, confusion_matrix, frequency_vs_f1, \
-    hyperopt_report
+    hyperopt_report, hyperopt_hiplot
 
 sys.path.append("../")
 
@@ -121,6 +121,7 @@ PAGES = [
             confusion_matrix,
             frequency_vs_f1,
             hyperopt_report,
+            hyperopt_hiplot
         ]
     }
     # {

--- a/src/code_doc_autogen.py
+++ b/src/code_doc_autogen.py
@@ -28,6 +28,7 @@ import re
 import sys
 
 from ludwig.api import kfold_cross_validate
+from ludwig.hyperopt.run import hyperopt
 from ludwig.visualize import learning_curves, compare_performance, \
     compare_classifiers_performance_from_prob, \
     compare_classifiers_performance_from_pred, \
@@ -91,7 +92,8 @@ PAGES = [
             (LudwigModel, "*")
         ],
         'functions': [
-            kfold_cross_validate
+            kfold_cross_validate,
+            hyperopt
         ]
     },
     {

--- a/src/code_doc_autogen.py
+++ b/src/code_doc_autogen.py
@@ -40,7 +40,8 @@ from ludwig.visualize import learning_curves, compare_performance, \
     confidence_thresholding_data_vs_acc, \
     confidence_thresholding_data_vs_acc_subset, binary_threshold_vs_metric, \
     roc_curves, roc_curves_from_test_statistics, calibration_1_vs_all, \
-    calibration_multiclass, confusion_matrix, frequency_vs_f1
+    calibration_multiclass, confusion_matrix, frequency_vs_f1, \
+    hyperopt_report
 
 sys.path.append("../")
 
@@ -119,6 +120,7 @@ PAGES = [
             calibration_multiclass,
             confusion_matrix,
             frequency_vs_f1,
+            hyperopt_report,
         ]
     }
     # {


### PR DESCRIPTION
Adding the `hyperopt` function to the ludwig model api page