### PR TITLE
doc: correct machine translation example

### DIFF
--- a/src/docs/examples.md
+++ b/src/docs/examples.md
@@ -157,6 +157,7 @@ output_features:
         decoder: generator
         cell_type: lstm
         attention: bahdanau
+        reduce_input: null
         loss:
             type: sampled_softmax_cross_entropy
         preprocessing:


### PR DESCRIPTION
Fixes issue https://github.com/ludwig-ai/ludwig/issues/1097

Added missing parameter to the machine translation example