### PR TITLE
Update getting_started to help activating directly the virtualenv

### DIFF
--- a/src/docs/getting_started.md
+++ b/src/docs/getting_started.md
@@ -40,7 +40,7 @@ brew install python3      # on mac
 You may want to use a virtual environment to maintain an isolated [Python environment](https://docs.python-guide.org/dev/virtualenvs/).
 
 ```
-virtualenv -p python3 venv
+virtualenv -p python3 venv && source venv/bin/activate
 ```
 
 In order to install Ludwig just run:


### PR DESCRIPTION
Minor change in order to help the unexperienced reader to correctly activate the virtual environment before installation.
See https://github.com/ludwig-ai/ludwig/pull/1212