### PR TITLE
Improvements and addressing feedback on command line interface and AutoML

### DIFF
--- a/docs/configuration/hyperparameter_optimization.md
+++ b/docs/configuration/hyperparameter_optimization.md
@@ -301,5 +301,5 @@ hyperopt:
 Example CLI command:
 
 ```
-ludwig hyperopt --dataset reuters-allcats.csv --config "{input_features: [{name: text, type: text, encoder: rnn, cell_type: lstm, num_layers: 2}], output_features: [{name: class, type: category}], training: {learning_rate: 0.001}, hyperopt: {goal: maximize, output_feature: class, metric: accuracy, split: validation, parameters: {trainer.learning_rate: {type: float, low: 0.0001, high: 0.1, steps: 4, scale: log}, text.cell_type: {type: category, values: [rnn, gru, lstm]}}, sampler: {type: grid}, executor: {type: serial}}}"
+ludwig hyperopt --dataset reuters-allcats.csv --config_str "{input_features: [{name: text, type: text, encoder: rnn, cell_type: lstm, num_layers: 2}], output_features: [{name: class, type: category}], training: {learning_rate: 0.001}, hyperopt: {goal: maximize, output_feature: class, metric: accuracy, split: validation, parameters: {trainer.learning_rate: {type: float, low: 0.0001, high: 0.1, steps: 4, scale: log}, text.cell_type: {type: category, values: [rnn, gru, lstm]}}, sampler: {type: grid}, executor: {type: serial}}}"
 ```

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -16,8 +16,8 @@ The Ludwig configuration mixes ease of use, by means of reasonable defaults, wit
 control over the parameters of your model. Only `input_features` and `output_features` are required while all other
 fields use reasonable defaults, but can be optionally set or modified manually.
 
-The config can be expressed as a python dictionary (`--config` for
-[Ludwig's CLI](../../docs/user_guide/command_line_interface)), or as a YAML file (`--config_file`).
+The config can be expressed as a python dictionary (`--config_str` for
+[Ludwig's CLI](../../docs/user_guide/command_line_interface)), or as a YAML file (`--config`).
 
 === "YAML"
 

--- a/docs/examples/forecasting.md
+++ b/docs/examples/forecasting.md
@@ -9,7 +9,7 @@ While direct timeseries prediction is a work in progress Ludwig can ingest times
 ```
 ludwig experiment \
 --dataset timeseries_data.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/fraud.md
+++ b/docs/examples/fraud.md
@@ -7,7 +7,7 @@
 ```
 ludwig experiment \
 --dataset transactions.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/fuel_efficiency.md
+++ b/docs/examples/fuel_efficiency.md
@@ -10,7 +10,7 @@ This example replicates the Keras example at <https://www.tensorflow.org/tutoria
 ```
 ludwig experiment \
 --dataset auto_mpg.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/image_classification.md
+++ b/docs/examples/image_classification.md
@@ -7,7 +7,7 @@
 ```
 ludwig experiment \
   --dataset image_classification.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/machine_translation.md
+++ b/docs/examples/machine_translation.md
@@ -7,7 +7,7 @@
 ```
 ludwig experiment \
   --dataset translation.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/mnist.md
+++ b/docs/examples/mnist.md
@@ -45,7 +45,7 @@ From the directory where you have virtual environment with ludwig installed:
 ludwig train \
   --training_set <PATH_TO_MNIST_DATASET_TRAINING_CSV> \
   --test_set <PATH_TO_MNIST_DATASET_TEST_CSV> \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:
@@ -93,7 +93,7 @@ training:
 ```
 ludwig experiment \
 --dataset image captioning.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/movie_ratings.md
+++ b/docs/examples/movie_ratings.md
@@ -7,7 +7,7 @@
 ```
 ludwig experiment \
 --dataset movie_ratings.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/multi_label.md
+++ b/docs/examples/multi_label.md
@@ -7,7 +7,7 @@
 ```
 ludwig experiment \
 --dataset image_data.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/multi_task.md
+++ b/docs/examples/multi_task.md
@@ -9,7 +9,7 @@ This example is inspired by the classic paper [Natural Language Processing (Almo
 ```
 ludwig experiment \
 --dataset nl_data.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/ner_tagging.md
+++ b/docs/examples/ner_tagging.md
@@ -7,7 +7,7 @@
 ```
 ludwig experiment \
   --dataset sequence_tags.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/nlu.md
+++ b/docs/examples/nlu.md
@@ -7,7 +7,7 @@
 ```
 ludwig experiment \
   --dataset nlu.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/oneshot.md
+++ b/docs/examples/oneshot.md
@@ -11,7 +11,7 @@ The task is, given two images of two handwritten characters, recognize if they a
 ```
 ludwig experiment \
 --dataset balinese_characters.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/sentiment_analysis.md
+++ b/docs/examples/sentiment_analysis.md
@@ -7,7 +7,7 @@
 ```
 ludwig experiment \
   --dataset sentiment.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/seq2seq.md
+++ b/docs/examples/seq2seq.md
@@ -7,7 +7,7 @@
 ```
 ludwig experiment \
   --dataset chitchat.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/speaker_verification.md
+++ b/docs/examples/speaker_verification.md
@@ -13,7 +13,7 @@ The sample data looks as follows:
 ```
 ludwig experiment \
 --dataset speaker_verification.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/speech_recognition.md
+++ b/docs/examples/speech_recognition.md
@@ -39,7 +39,7 @@ From the directory where you have virtual environment with ludwig installed:
 ```
 ludwig experiment \
   --dataset <PATH_TO_SPOKEN_DIGIT_CSV> \
-  --config_file config_file.yaml
+  --config config_file.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/text_classification.md
+++ b/docs/examples/text_classification.md
@@ -11,7 +11,7 @@ Other datasets available on the same webpage, like [OHSUMED](http://boston.lti.c
 ```
 ludwig experiment \
   --dataset text_classification.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/titanic.md
+++ b/docs/examples/titanic.md
@@ -16,7 +16,7 @@ After downloading the data, to train a model on this dataset using Ludwig,
 ```
 ludwig experiment \
   --dataset <PATH_TO_TITANIC_CSV> \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/visual_qa.md
+++ b/docs/examples/visual_qa.md
@@ -7,7 +7,7 @@
 ```
 ludwig experiment \
 --dataset vqa.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/examples/weather.md
+++ b/docs/examples/weather.md
@@ -46,7 +46,7 @@ df.to_csv('<PATH_TO_FILE>/temperature_la.csv')
 ```
 ludwig experiment \
 --dataset <PATH_TO_FILE>/temperature_la.csv \
-  --config_file config.yaml
+  --config config.yaml
 ```
 
 With `config.yaml`:

--- a/docs/user_guide/automl.md
+++ b/docs/user_guide/automl.md
@@ -1,4 +1,5 @@
-Ludwig supports AutoML, which returns a tuned Deep Learning model, given a dataset, the target column, and a time budget.
+Ludwig AutoML takes a dataset, the target column, and a time budget, and returns
+a trained Ludwig model.
 
 Ludwig AutoML is currently experimental and is focused on tabular datasets.  A blog describing its development, evaluation,
 and use is [here](https://medium.com/ludwig-ai/ludwig-automl-for-deep-learning-cf64de9d49c8).

--- a/docs/user_guide/command_line_interface.md
+++ b/docs/user_guide/command_line_interface.md
@@ -2,25 +2,25 @@
 
 Ludwig provides several functions through its command line interface.
 
-| Mode                  | Description                                                                       |
-| --------------------- | --------------------------------------------------------------------------------- |
-| `train`               | Trains a model                                                                    |
-| `predict`             | Predicts using a pretrained model                                                 |
-| `evaluate`            | Evaluate a pretrained model's performance                                         |
-| `experiment`          | Runs a full experiment training a model and evaluating it                         |
-| `hyperopt`            | Perform hyperparameter optimization                                               |
-| `serve`               | Serves a pretrained model                                                         |
-| `visualize`           | Visualizes experiment results                                                     |
-| `init_config`         | Initialize a user config from a dataset and targets                               |
-| `render_config`       | Renders the fully populated config with all defaults set                          |
-| `collect_summary`     | Prints names of weights and layers activations to use with other collect commands |
-| `collect_weights`     | Collects tensors containing a pretrained model weights                            |
-| `collect_activations` | Collects tensors for each datapoint using a pretrained model                      |
-| `export_torchscript`  | Exports Ludwig models to Torchscript                                              |
-| `export_neuropod`     | Exports Ludwig models to Neuropod                                                 |
-| `export_mlflow`       | Exports Ludwig models to MLflow                                                   |
-| `preprocess`          | Preprocess data and saves it into HDF5 and JSON format                            |
-| `synthesize_dataset`  | Creates synthetic data for testing purposes                                       |
+| Mode                                          | Description                                                                       |
+| --------------------------------------------- | --------------------------------------------------------------------------------- |
+| [`train`](#train)                             | Trains a model                                                                    |
+| [`predict`](#predict)                         | Predicts using a pretrained model                                                 |
+| [`evaluate`](#evaluate)                       | Evaluate a pretrained model's performance                                         |
+| [`experiment`](#experiment)                   | Runs a full experiment training a model and evaluating it                         |
+| [`hyperopt`](#hyperopt)                       | Perform hyperparameter optimization                                               |
+| [`serve`](#serve)                             | Serves a pretrained model                                                         |
+| [`visualize`](#visualize)                     | Visualizes experiment results                                                     |
+| [`init_config`](#init_config)                 | Initialize a user config from a dataset and targets                               |
+| [`render_config`](#render_config)             | Renders the fully populated config with all defaults set                          |
+| [`collect_summary`](#collect_summary)         | Prints names of weights and layers activations to use with other collect commands |
+| [`collect_weights`](#collect_weights)         | Collects tensors containing a pretrained model weights                            |
+| [`collect_activations`](#collect_activations) | Collects tensors for each datapoint using a pretrained model                      |
+| [`export_torchscript`](#export_torchscript)   | Exports Ludwig models to Torchscript                                              |
+| [`export_neuropod`](#export_neuropod)         | Exports Ludwig models to Neuropod                                                 |
+| [`export_mlflow`](#export_mlflow)             | Exports Ludwig models to MLflow                                                   |
+| [`preprocess`](#preprocess)                   | Preprocess data and saves it into HDF5 and JSON format                            |
+| [`synthesize_dataset`](#synthesize_dataset)   | Creates synthetic data for testing purposes                                       |
 
 These are described in detail below.
 
@@ -74,9 +74,9 @@ optional arguments:
   -sspi, --skip_save_processed_input
                         skips saving intermediate HDF5 and JSON files
   -c CONFIG, --config CONFIG
-                        config
-  -cf CONFIG_FILE, --config_file CONFIG_FILE
-                        YAML file describing the model. Ignores --config
+                        Path to the YAML file containing the model configuration
+  -cs CONFIG_STR, --config_str CONFIG_STRING
+                        JSON or YAML serialized string of the model configuration. Ignores --config
   -mlp MODEL_LOAD_PATH, --model_load_path MODEL_LOAD_PATH
                         path of a pretrained model to load as initialization
   -mrp MODEL_RESUME_PATH, --model_resume_path MODEL_RESUME_PATH
@@ -161,8 +161,9 @@ The directory will contain
 - `training_statistics.json` - a file containing records of all measures and losses for each epoch.
 - `model` - a directory containing model hyperparameters, weights, checkpoints and logs (for TensorBoard).
 
-The configuration can be provided either as a string (`--config`)
-or as YAML file (`--config_file`).
+The configuration can be provided either as a string (`--config_str`)
+or as YAML file (`--config`).
+
 Details on how to write your configuration are provided in the [Configuration](#configuration) section.
 
 During training Ludwig saves two sets of weights for the model, one that is the
@@ -195,7 +196,7 @@ Finally the `--logging_level` argument lets you set the amount of logging that y
 
 Example:
 
-```
+```bash
 ludwig train --dataset reuters-allcats.csv --config "{input_features: [{name: text, type: text, encoder: parallel_cnn, level: word}], output_features: [{name: class, type: category}]}"
 ```
 
@@ -276,7 +277,7 @@ Finally the `--logging_level`, `--debug`, `--gpus`, `--gpu_memory_limit` and `--
 
 Example:
 
-```
+```bash
 ludwig predict --dataset reuters-allcats.csv --model_path results/experiment_run_0/model/
 ```
 
@@ -358,9 +359,10 @@ ludwig evaluate --dataset reuters-allcats.csv --model_path results/experiment_ru
 
 # experiment
 
-This command combines training and evaluation into a single handy command.\
-You can request a k-fold cross validation run by specifying the `--k_fold`
+This command combines training and evaluation into a single handy command. You
+can request a k-fold cross validation run by specifying the `--k_fold`
 parameter.
+
 You can call it with:
 
 ```bash
@@ -420,10 +422,9 @@ optional arguments:
                         it is not needed turning it off can slightly increase
                         the overall speed
   -c CONFIG, --config CONFIG
-                        config
-  -cf CONFIG_FILE, --config_file CONFIG_FILE
-                        YAML file describing the model. Ignores
-                        --model_hyperparameters
+                        Path to the YAML file containing the model configuration
+  -cs CONFIG_STR, --config_str CONFIG_STRING
+                        JSON or YAML serialized string of the model configuration. Ignores --config
   -mlp MODEL_LOAD_PATH, --model_load_path MODEL_LOAD_PATH
                         path of a pretrained model to load as initialization
   -mrp MODEL_RESUME_PATH, --model_resume_path MODEL_RESUME_PATH
@@ -540,10 +541,9 @@ optional arguments:
   -sspi, --skip_save_processed_input
                         skips saving intermediate HDF5 and JSON files
   -c CONFIG, --config CONFIG
-                        config
-  -cf CONFIG_FILE, --config_file CONFIG_FILE
-                        YAML file describing the model. Ignores
-                        --model_hyperparameters
+                        Path to the YAML file containing the model configuration
+  -cs CONFIG_STR, --config_str CONFIG_STRING
+                        JSON or YAML serialized string of the model configuration. Ignores --config
   -mlp MODEL_LOAD_PATH, --model_load_path MODEL_LOAD_PATH
                         path of a pretrained model to load as initialization
   -mrp MODEL_RESUME_PATH, --model_resume_path MODEL_RESUME_PATH
@@ -632,6 +632,11 @@ optional arguments:
 The most important argument is `--model_path` where you have to specify the path of the model to load.
 
 Once running, you can make a POST request on the `/predict` endpoint to run inference on the form data submitted.
+
+!!! note
+
+    `ludwig serve` will automatically use GPUs for serving, if avaiable to the
+    machine-local torch environment.
 
 ## Example curl
 
@@ -744,6 +749,8 @@ Each of them requires a different subset of this command's arguments, so they wi
 
 # init_config
 
+Initialize a user config from a dataset and targets.
+
 ```
 usage: ludwig init_config [options]
 
@@ -769,6 +776,8 @@ optional arguments:
 ```
 
 # render_config
+
+Renders the fully populated config with all defaults set.
 
 ```
 usage: ludwig render_config [options]
@@ -852,18 +861,19 @@ optional arguments:
 
 The three most important arguments are `--model_path` where you have to specify the path of the model to load, `--tensors` that lets you specify a list of tensor names in the Torch graph that contain the weights you want to collect, and finally `--output_directory` that lets you specify where the NPY files (one for each tensor name specified) will be saved.
 
-In order to figure out the names of the tensors containing the weights you want to collect, the best way is to inspect the graph of the model with TensorBoard.
-
-```bash
-tensorboard --logdir /path/to/model/log
-```
-
-Or use the `collect_summary` command.
+In order to figure out the names of the tensors containing the weights you want
+to collect, use the `collect_summary` command.
 
 # collect_activations
 
-This command lets you load a pre-trained model and input data and collects the values of activations contained in tensors with a specific name in order to save them in a NPY format.
-This may be useful in order to visualize the activations (for instance collecting last layer's activations as embeddings representations of the input datapoint) and for some post-hoc analyses.
+This command lets you load a pre-trained model and input data and collects the
+values of activations contained in tensors with a specific name in order to save
+them in a NPY format.
+
+This may be useful in order to visualize the activations (for instance
+collecting the last layer's activations as embeddings representations of the
+input datapoint) and for some post-hoc analyses.
+
 You can call it with:
 
 ```bash
@@ -917,14 +927,13 @@ optional arguments:
                         the level of logging to use
 ```
 
-The data related and runtime related arguments (GPUs, batch size, etc.) are the same used in [predict](#predict), you can refer to that section for an explanation.
-The collect specific arguments `--model_path`, `--tensors` and `--output_directory` are the same used in [collect_weights](#collect_weights), you can refer to that section for an explanation.
+The data related and runtime related arguments (GPUs, batch size, etc.) are the
+same as the ones used in [predict](#predict), you can refer to that section for
+an explanation.
 
-In order to figure out the names of the tensors containing the activations you want to collect, the best way is to inspect the graph of the model with TensorBoard.
-
-```
-tensorboard --logdir /path/to/model/log
-```
+The collect-specific arguments, `--model_path`, `--tensors` and
+`--output_directory`, are the same used in [collect_weights](#collect_weights),
+you can refer to that section for an explanation.
 
 # export_torchscript
 

--- a/docs/user_guide/visualizations.md
+++ b/docs/user_guide/visualizations.md
@@ -882,3 +882,11 @@ The visualization creates an interactive HTML page visualizing all the results f
 once using a parallel coordinate plot.
 
 ![Hiplot hyperopt plot](../images/hyperopt_hiplot.jpeg "Hiplot hyperopt plot")
+
+# Tensorboard
+
+Users can visualize raw training metrics on Tensorboard with:
+
+```bash
+tensorboard --logdir </path/to/model>/log
+```


### PR DESCRIPTION
DONE - make the command names in the table clickable to get to specific section in the same page

DONE - The configuration can be provided either as a string (--config) or as YAML file (--config_file). Details on how to write your configuration are provided in the Configuration section. -> this changed, update it.

DONE(Seems to be true) - You can manage which GPUs on your machine are used with the --gpus argument -> let’s make sure that all the info here is true and current

DONE - doublecheck config/config_file/config_str everywere

DONE - o a single handy command.\ Yo The \ character is a typo

DONE - the experiment example command has the config string in yellow, the others dont’, it’s probably about the language specified in the markdown code block ```bash or somethign like it. Make sure all bash commands use the same color highlighting

DONE - add a sentence to explain how serve uses or not GPUs

[ACK] - init_config is not a great name, what abour create_config or generate_config?

DONE - inir_config and render_config Need some text explaining in mode detail what they do and why they are needed

DONE - collect_weights: In order to figure out the names of the tensors containing the weights you want to collect, the best way is to inspect the graph of the model with TensorBoard. -> this isn’t true anymore

DONE - collect-activations: In order to figure out the names of the tensors containing the weights you want to collect, the best way is to inspect the graph of the model with TensorBoard. -> this isn’t true anymore + we need to say how to use collect summary for it

AutoML:

DONE - Ludwig supports AutoML, which returns a tuned Deep Learning model, given a dataset, the target column, and a time budget. -> not a great intro sentence, improve with more explanation.