### PR TITLE
Removes level param for text features, changes word_tokenizer to tokenizer

### DIFF
--- a/docs/configuration/features/input_features.md
+++ b/docs/configuration/features/input_features.md
@@ -78,9 +78,8 @@ the encoders that can be used for a certain data type can also be found in each 
             name: text
             type: text
             encoder: bert
-            level: word
             preprocessing:
-                word_tokenizer: space
+                tokenizer: space
             reduce_output: null
             trainable: true
     ```

--- a/docs/configuration/features/text_features.md
+++ b/docs/configuration/features/text_features.md
@@ -29,17 +29,11 @@ Configuration example:
 ```yaml
 name: text_column_name
 type: text
-level: word
 preprocessing:
-    char_tokenizer: characters
-    char_vocab_file: null
-    char_sequence_length_limit: 1024
-    char_most_common: 70
-    word_tokenizer: space_punct
-    pretrained_model_name_or_path: null
-    word_vocab_file: null
-    word_sequence_length_limit: 256
-    word_most_common: 20000
+    tokenizer: space_punct
+    vocab_file: null
+    max_sequence_length: 256
+    most_common: 20000
     padding_symbol: <PAD>
     unknown_symbol: <UNK>
     padding: right
@@ -100,7 +94,6 @@ Example text input feature using default values:
 ```yaml
 name: sequence_column_name
 type: text
-level: word
 decoder: generator
 reduce_input: sum
 dependencies: []

--- a/docs/examples/machine_translation.md
+++ b/docs/examples/machine_translation.md
@@ -17,18 +17,16 @@ input_features:
     -
         name: english
         type: text
-        level: word
         encoder: rnn
         cell_type: lstm
         reduce_output: null
         preprocessing:
-          word_tokenizer: english_tokenize
+          tokenizer: english_tokenize
 
 output_features:
     -
         name: italian
         type: text
-        level: word
         decoder: generator
         cell_type: lstm
         attention: bahdanau
@@ -36,7 +34,7 @@ output_features:
         loss:
             type: sampled_softmax_cross_entropy
         preprocessing:
-          word_tokenizer: italian_tokenize
+          tokenizer: italian_tokenize
 
 training:
     batch_size: 96

--- a/docs/examples/mnist.md
+++ b/docs/examples/mnist.md
@@ -109,7 +109,6 @@ output_features:
     -
         name: caption
         type: text
-        level: word
         decoder: generator
         cell_type: lstm
 ```

--- a/docs/examples/ner_tagging.md
+++ b/docs/examples/ner_tagging.md
@@ -17,12 +17,11 @@ input_features:
     -
         name: utterance
         type: text
-        level: word
         encoder: rnn
         cell_type: lstm
         reduce_output: null
         preprocessing:
-          word_tokenizer: space
+          tokenizer: space
 
 output_features:
     -

--- a/docs/examples/nlu.md
+++ b/docs/examples/nlu.md
@@ -17,14 +17,13 @@ input_features:
     -
         name: utterance
         type: text
-        level: word
         encoder: rnn
         cell_type: lstm
         bidirectional: true
         num_layers: 2
         reduce_output: null
         preprocessing:
-          word_tokenizer: space
+          tokenizer: space
 
 output_features:
     -

--- a/docs/examples/sentiment_analysis.md
+++ b/docs/examples/sentiment_analysis.md
@@ -17,7 +17,6 @@ input_features:
     -
         name: review
         type: text
-        level: word
         encoder: parallel_cnn
 
 output_features:

--- a/docs/examples/seq2seq.md
+++ b/docs/examples/seq2seq.md
@@ -17,7 +17,6 @@ input_features:
     -
         name: user1
         type: text
-        level: word
         encoder: rnn
         cell_type: lstm
         reduce_output: null
@@ -26,7 +25,6 @@ output_features:
     -
         name: user2
         type: text
-        level: word
         decoder: generator
         cell_type: lstm
         attention: bahdanau

--- a/docs/examples/visual_qa.md
+++ b/docs/examples/visual_qa.md
@@ -21,14 +21,12 @@ input_features:
     -
         name: question
         type: text
-        level: word
         encoder: parallel_cnn
 
 output_features:
     -
         name: answer
         type: text
-        level: word
         decoder: generator
         cell_type: lstm
         loss:

--- a/docs/user_guide/command_line_interface.md
+++ b/docs/user_guide/command_line_interface.md
@@ -197,7 +197,7 @@ Finally the `--logging_level` argument lets you set the amount of logging that y
 Example:
 
 ```bash
-ludwig train --dataset reuters-allcats.csv --config "{input_features: [{name: text, type: text, encoder: parallel_cnn, level: word}], output_features: [{name: class, type: category}]}"
+ludwig train --dataset reuters-allcats.csv --config "{input_features: [{name: text, type: text, encoder: parallel_cnn}], output_features: [{name: class, type: category}]}"
 ```
 
 # predict
@@ -485,7 +485,7 @@ The output directory will contain the outputs both commands produce.
 Example:
 
 ```bash
-ludwig experiment --dataset reuters-allcats.csv --config "{input_features: [{name: text, type: text, encoder: parallel_cnn, level: word}], output_features: [{name: class, type: category}]}"
+ludwig experiment --dataset reuters-allcats.csv --config "{input_features: [{name: text, type: text, encoder: parallel_cnn}], output_features: [{name: class, type: category}]}"
 ```
 
 # hyperopt


### PR DESCRIPTION
Except for text_classification.md, which is done in the '[Adds updated text classification example with Colab notebooks](https://github.com/ludwig-ai/ludwig-docs/pull/101)' PR