### PR TITLE
add `tied` parameter for missing input features

### DIFF
--- a/docs/configuration/features/binary_features.md
+++ b/docs/configuration/features/binary_features.md
@@ -20,6 +20,7 @@ missing values with the next valid value), or `fill_with_false` (default, replac
 ```yaml
 name: binary_column_name
 type: binary
+tied: null
 encoder: passthrough
 ```
 
@@ -30,6 +31,12 @@ transformed to outputs of size `b x 1` where `b` is the batch size.
 
 The `dense` encoder passes the raw binary values through a fully connected layer. Inputs of size `b` are transformed to
 size `b x h`.
+
+
+The available encoder parameters are:
+
+- `tied` (default `null`): name of the input feature to tie the weights of the encoder with. It needs to be the name of
+a feature of the same type and with the same encoder parameters.
 
 ### Passthrough Encoder
 

--- a/docs/configuration/features/binary_features.md
+++ b/docs/configuration/features/binary_features.md
@@ -32,7 +32,6 @@ transformed to outputs of size `b x 1` where `b` is the batch size.
 The `dense` encoder passes the raw binary values through a fully connected layer. Inputs of size `b` are transformed to
 size `b x h`.
 
-
 The available encoder parameters are:
 
 - `tied` (default `null`): name of the input feature to tie the weights of the encoder with. It needs to be the name of

--- a/docs/configuration/features/vector_features.md
+++ b/docs/configuration/features/vector_features.md
@@ -19,6 +19,11 @@ Preprocessing parameters:
 
 The vector feature supports two encoders: `dense` and `passthrough`.
 
+The available encoder parameters are:
+
+- `tied` (default `null`): name of the input feature to tie the weights of the encoder with. It needs to be the name of
+a feature of the same type and with the same encoder parameters.
+
 ### Passthrough Encoder
 
 There are no additional parameters for the `passthrough` encoder.
@@ -45,6 +50,7 @@ Example vector feature entry in the input features list using an dense encoder:
 ```yaml
 name: vector_column_name
 type: vector
+tied: null
 encoder: dense
 layers: null
 num_layers: 0


### PR DESCRIPTION
Adds description for `tied` parameter where missing, i.e. vector and binary input features.