### PR TITLE
Removes sampled_softmax_cross_entropy and its params

### DIFF
--- a/docs/configuration/features/sequence_features.md
+++ b/docs/configuration/features/sequence_features.md
@@ -993,9 +993,8 @@ but a matrix or a higher order tensor, on the first dimension (second if you cou
 values are: `sum`, `mean` or `avg`, `max`, `concat` (concatenates along the sequence dimension), `last` (returns the
 last vector of the sequence dimension).
 - `loss` (default `{type: softmax_cross_entropy, class_similarities_temperature: 0, class_weights: 1,
-confidence_penalty: 0, distortion: 1, labels_smoothing: 0, negative_samples: 0, robust_lambda: 0, sampler: null, unique:
-false}`): is a dictionary containing a loss `type`. The available losses `type` are `softmax_cross_entropy` and
-`sampled_softmax_cross_entropy`. For details on both losses, please refer to
+confidence_penalty: 0, robust_lambda: 0}`): is a dictionary containing a loss `type`. The only available
+loss `type` for sequences is `softmax_cross_entropy`. For more details on losses and their options, see also
 [Category Output Features and Decoders](../category_features#category-output-features-and-decoders).
 
 ### Tagger Decoder
@@ -1071,10 +1070,6 @@ loss:
     robust_lambda: 0
     class_weights: 1
     class_similarities_temperature: 0
-    labels_smoothing: 0
-    negative_samples: 0
-    distortion: 1
-    unique: false
 num_fc_layers: 0
 output_size: 256
 use_bias: true
@@ -1183,10 +1178,6 @@ loss:
     robust_lambda: 0
     class_weights: 1
     class_similarities_temperature: 0
-    labels_smoothing: 0
-    negative_samples: 0
-    distortion: 1
-    unique: false
 num_fc_layers: 0
 output_size: 256
 use_bias: true

--- a/docs/configuration/features/text_features.md
+++ b/docs/configuration/features/text_features.md
@@ -1094,9 +1094,8 @@ but a matrix or a higher order tensor, on the first dimension (second if you cou
 values are: `sum`, `mean` or `avg`, `max`, `concat` (concatenates along the sequence dimension), `last` (returns the
 last vector of the sequence dimension).
 - `loss` (default `{type: softmax_cross_entropy, class_similarities_temperature: 0, class_weights: 1,
-confidence_penalty: 0, distortion: 1, labels_smoothing: 0, negative_samples: 0, robust_lambda: 0, sampler: null, unique:
-false}`): is a dictionary containing a loss `type`. The available losses `type` are `softmax_cross_entropy` and
-`sampled_softmax_cross_entropy`. For details on both losses, please refer to
+confidence_penalty: 0, robust_lambda: 0}`): is a dictionary containing a loss `type`. The only available loss `type` for
+text features is `softmax_cross_entropy`. For more details on losses and their options, see also
 [Category Output Features and Decoders](../category_features#category-output-features-and-decoders).
 
 ### Tagger Decoder
@@ -1172,10 +1171,6 @@ loss:
     robust_lambda: 0
     class_weights: 1
     class_similarities_temperature: 0
-    labels_smoothing: 0
-    negative_samples: 0
-    distortion: 1
-    unique: false
 num_fc_layers: 0
 output_size: 256
 use_bias: true
@@ -1284,10 +1279,6 @@ loss:
     robust_lambda: 0
     class_weights: 1
     class_similarities_temperature: 0
-    labels_smoothing: 0
-    negative_samples: 0
-    distortion: 1
-    unique: false
 num_fc_layers: 0
 output_size: 256
 use_bias: true

--- a/docs/examples/machine_translation.md
+++ b/docs/examples/machine_translation.md
@@ -32,7 +32,7 @@ output_features:
         attention: bahdanau
         reduce_input: null
         loss:
-            type: sampled_softmax_cross_entropy
+            type: softmax_cross_entropy
         preprocessing:
           tokenizer: italian_tokenize
 

--- a/docs/examples/seq2seq.md
+++ b/docs/examples/seq2seq.md
@@ -29,7 +29,7 @@ output_features:
         cell_type: lstm
         attention: bahdanau
         loss:
-            type: sampled_softmax_cross_entropy
+            type: softmax_cross_entropy
 
 training:
     batch_size: 96

--- a/docs/examples/visual_qa.md
+++ b/docs/examples/visual_qa.md
@@ -30,5 +30,5 @@ output_features:
         decoder: generator
         cell_type: lstm
         loss:
-            type: sampled_softmax_cross_entropy
+            type: softmax_cross_entropy
 ```


### PR DESCRIPTION
Removes references to `sampled_softmax_cross_entropy` and
`labels_smoothing`, `negative_samples`, `distortion`, `sampler`, `unique`.
