### PR TITLE
Add max_concurrent_trials parameter to Tune Executor

### DIFF
--- a/docs/configuration/hyperparameter_optimization.md
+++ b/docs/configuration/hyperparameter_optimization.md
@@ -174,6 +174,8 @@ The `ray` executor is used to enable [Ray Tune](https://docs.ray.io/en/master/tu
 - `gpu_resources_per_trial`: The number of GPU devices allocated to each trial (default: 0).
 - `kubernetes_namespace`: When running on Kubernetes, provide the namespace of the Ray cluster to sync results between pods. See the [Ray docs](https://docs.ray.io/en/master/_modules/ray/tune/integration/kubernetes.html) for more info.
 - `time_budget_s`: The number of seconds for the entire hyperopt run.
+- `max_concurrent_trials`: The maximum number of trials to
+train concurrently. Defaults to `num_samples`.
 
 ## Scheduler
 


### PR DESCRIPTION
Add `max_concurrent_trials` to the Ludwig docs for hyperopt executor. 