### PR TITLE
Add documentation for hyperopting over nested configs

### DIFF
--- a/docs/configuration/hyperparameter_optimization.md
+++ b/docs/configuration/hyperparameter_optimization.md
@@ -143,6 +143,17 @@ hyperopt:
         - [{"output_size": 256}]
 ```
 
+### Default Hyperopt Parameters
+
+In addition to defining hyperopt parameters for individual input or output features (like the `title` feature
+in the example above), default parameters can be specified for entire feature types (for example, the encoder
+to use for all text features in your dataset). Read more about default hyperopt parameters [here](../user_guide/hyperopt.md#default-hyperopt-parameters).
+
+### Nested Ludwig Config Parameters
+
+Ludwig also allows partial or full Ludwig configs to be sampled from the hyperopt search space.
+Read more about nested Ludwig config parameters [here](../user_guide/hyperopt.md#nested-ludwig-config-parameters).
+
 # Search Algorithm
 
 Ray Tune supports its own collection of [search algorithms](https://docs.ray.io/en/master/tune/api_docs/suggestion.html), specified by the `search_alg` section of the hyperopt config:

--- a/docs/user_guide/hyperopt.md
+++ b/docs/user_guide/hyperopt.md
@@ -92,12 +92,12 @@ hyperopt:
     parameters:
         .:  space: choice
             categories: 
-                -   combiner:
+                -   combiner: # Ludwig config subsection 1
                         type: tabnet
                     trainer:
                         learning_rate: 0.001
                         batch_size: 64
-                -   combiner:
+                -   combiner: # Ludwig config subsection 2
                         type: concat
                     trainer:
                         batch_size: 256
@@ -108,7 +108,7 @@ hyperopt:
 ```
 
 The `.` parameter defines the nested hyperopt parameter with two choices. These will be sampled and
-used to update the Ludwig config for each trial based on which of the two choices are sampled.
+used to update the Ludwig config for each trial based on which of the two choices is picked.
 
 This config above will create hyperopt samples that look like the following:
 

--- a/docs/user_guide/hyperopt.md
+++ b/docs/user_guide/hyperopt.md
@@ -77,6 +77,66 @@ In this example, `defaults.text.preprocessing.most_common` is a default paramete
 this parameter will modify preprocessing for all text input features
 - `most_common` is the parameter within `preprocessing` that we want to modify for all text input features
 
+## Nested Ludwig Config Parameters
+
+Ludwig also extends the range of hyperopt parameters to support parameter choices that consist of partial or
+complete blocks of nested Ludwig config sections. This allows users to search over a set of Ludwig configs, as
+opposed to needing to specify config params individually and search over all combinations.
+
+To provide a parameter that represents a subsection of the Ludwig config, the `.` key name can be used.
+
+For example, one can define a hyperopt search space like the one below and sample partial Ludwig configs:
+
+```yaml
+hyperopt:
+    parameters:
+        .:  space: choice
+            categories: 
+                -   combiner:
+                        type: tabnet
+                    trainer:
+                        learning_rate: 0.001
+                        batch_size: 64
+                -   combiner:
+                        type: concat
+                    trainer:
+                        batch_size: 256
+        trainer.decay_rate:
+            space: loguniform
+            lower: 0.001
+            upper: 0.1
+```
+
+The `.` parameter defines the nested hyperopt parameter with two choices. These will be sampled and
+used to update the Ludwig config for each trial based on which of the two choices are sampled.
+
+This config above will create hyperopt samples that look like the following:
+
+```yaml
+# Trial 1
+  combiner:
+    type: tabnet
+  trainer: 
+  learning_rate: 0.001
+  batch_size: 64
+  decay_rate: 0.02
+
+# Trial 2
+  combiner:
+    type: tabnet
+  trainer: 
+    learning_rate: 0.001
+    batch_size: 64
+    decay_rate: 0.001
+
+# Trial 3
+  combiner:
+    type: concat
+  trainer: 
+    batch_size: 64
+    decay_rate: 0.001
+```
+
 # Running Hyperparameter Optimization
 
 Use the `ludwig hyperopt` command to run hyperparameter optimization.

--- a/docs/user_guide/hyperopt.md
+++ b/docs/user_guide/hyperopt.md
@@ -80,8 +80,8 @@ this parameter will modify preprocessing for all text input features
 ## Nested Ludwig Config Parameters
 
 Ludwig also extends the range of hyperopt parameters to support parameter choices that consist of partial or
-complete blocks of nested Ludwig config sections. This allows users to search over a set of Ludwig configs, as
-opposed to needing to specify config params individually and search over all combinations.
+complete blocks of Ludwig config sections. This allows users to search over a set of Ludwig configs, as
+opposed to needing to specify config params individually and search over all combinations of parameters.
 
 To provide a parameter that represents a subsection of the Ludwig config, the `.` key name can be used.
 


### PR DESCRIPTION
This PR adds documentation for nested hyperopt configs.

<img width="442" alt="Screen Shot 2022-09-19 at 4 27 03 PM" src="https://user-images.githubusercontent.com/106701836/191122593-7bb2bb2d-986c-4d29-aaec-ee2a0a2613e8.png">
