### PR TITLE
Fixed edit_uri

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ site_url: https://ludwig.ai/
 # Repository
 repo_name: ludwig-ai/ludwig
 repo_url: https://github.com/ludwig-ai/ludwig
-edit_uri: https://github.com/ludwig-ai/ludwig-docs/edit/master/src/docs/
+edit_uri: https://github.com/ludwig-ai/ludwig-docs/edit/master/docs/
 
 # Copyright
 copyright: Copyright &copy; 2018 - 2020 Uber Technologies Inc., 2021 - 2022 Linux Foundation Data & AI


### PR DESCRIPTION
The edit button on a page in the documentation did not work but gave a 404.

This fixes the edit_uri to work with GitHub