### PR TITLE
Fix image height and width inference description

### DIFF
--- a/docs/configuration/features/image_features.md
+++ b/docs/configuration/features/image_features.md
@@ -35,7 +35,7 @@ Image height in pixels. If set, images will be resized to the specified height u
 
 ### `width`
 
-Image width in pixels. If set, images will be resized to the specified width using the `resize_method` parameter. 
+Image width in pixels. If set, images will be resized to the specified width using the `resize_method` parameter.
 If unspecified, images will be resized based on the average width of the first 100 images in the dataset. This can be controlled by the `infer_image_sample_size` attribute.
 
 - Default: `null`

--- a/docs/configuration/features/image_features.md
+++ b/docs/configuration/features/image_features.md
@@ -29,15 +29,14 @@ During preprocessing, raw image files are transformed into numpy arrays and save
 
 ### `height`
 
-Image height in pixels. If set, images will be resized to the specified height using the `resize_method` parameter. If
-unspecified, images will be resized to the size of the first image in the dataset.
+Image height in pixels. If set, images will be resized to the specified height using the `resize_method` parameter. If unspecified, images will be resized based on the average height of the first 100 images in the dataset. This can be controlled by the `infer_image_sample_size` attribute.
 
 - Default: `null`
 
 ### `width`
 
-Image width in pixels. If set, images will be resized to the specified width using the `resize_method` parameter. If
-unspecified, images will be resized to the size of the first image in the dataset.
+Image width in pixels. If set, images will be resized to the specified width using the `resize_method` parameter. 
+If unspecified, images will be resized based on the average width of the first 100 images in the dataset. This can be controlled by the `infer_image_sample_size` attribute.
 
 - Default: `null`
 


### PR DESCRIPTION
As far as I understand, we now use a sample of images to infer width and height rather than just the first image if height and width aren't specified. 

This updates the documentation to reflect this change.