### PR TITLE
Update feature configuration

### DIFF
--- a/docs/configuration/defaults.md
+++ b/docs/configuration/defaults.md
@@ -132,7 +132,7 @@ Sequence, text, and set features tokenize features as part of preprocessing. The
 - `space`: splits on space characters using the regex `\s+`.
 - `space_punct`: splits on space characters and punctuation using the regex `\w+|[^\w\s]`.
 - `underscore`: splits on the underscore character `_`.
-- `comma`: splits on the underscore character `,`.
+- `comma`: splits on the comma character `,`.
 - `untokenized`: treats the whole string as a single token.
 - `stripped`: treats the whole string as a single token after removing spaces at the beginning and at the end of the string.
 - `ngram`: this will create a vocab that consists of unigrams and bigrams.

--- a/docs/configuration/features/binary_features.md
+++ b/docs/configuration/features/binary_features.md
@@ -104,7 +104,7 @@ reduce_input: sum
 dependencies: []
 reduce_dependencies: sum
 loss:
-    type: cross_entropy
+    type: binary_weighted_cross_entropy
     confidence_penalty: 0
     robust_lambda: 0
     positive_class_weight: 1
@@ -140,8 +140,8 @@ output probabilities closer to true likelihoods.
 but a matrix or a higher order tensor, on the first dimension (second if you count the batch dimension). Available
 values are: `sum`, `mean` or `avg`, `max`, `concat` (concatenates along the first dimension), `last` (returns the last
 vector of the first dimension).
-- `loss` (default `{type: cross_entropy, confidence_penalty: 0, robust_lambda: 0, positive_class_weight: 1}`): is a
-dictionary containing a loss `type` and its hyperparameters. The only available loss `type` is `cross_entropy` (cross
+- `loss` (default `{type: binary_weighted_cross_entropy, confidence_penalty: 0, robust_lambda: 0, positive_class_weight: 1}`): is a
+dictionary containing a loss `type` and its hyperparameters. The only available loss `type` is `binary_weighted_cross_entropy` (cross
 entropy), and the optional parameters are `confidence_penalty` (an additional term that penalizes too confident
 predictions by adding a `a * (max_entropy - entropy) / max_entropy` term to the loss, where a is the value of this
 parameter), `robust_lambda` (replaces the loss with `(1 - robust_lambda) * loss + robust_lambda / 2` which is useful in


### PR DESCRIPTION
When trying to use cross_entropy, I got the following error:

```
marshmallow.exceptions.ValidationError: {'loss': ["Invalid params for loss: {'type': 'cross_entropy', 'positive_class_weight': 1, 'class_weights': None, 'confidence_penalty': 0.0, 'weight': 1.0, 'robust_lambda': 0}, expect dict with at least a valid `type` attribute."]}
```

This matches what's supported in constants.

https://github.com/ludwig-ai/ludwig/blob/9c2ac5f15d9a48766e54c90726a1effe861a6382/ludwig/constants.py#L56