### PR TITLE
Fix label typo in the Large Language Models page

### DIFF
--- a/docs/configuration/large_language_model.md
+++ b/docs/configuration/large_language_model.md
@@ -141,7 +141,7 @@ output_features:
       match:
           "negative":
               type: contains
-              value: "positive"
+              value: "negative"
           "neutral":
               type: contains
               value: "neutral"


### PR DESCRIPTION
Fix a minor type that I noticed when following this tutorial. It was using the wrong value for the `negative` label.