### PR TITLE
[BUGFIX] Provide Documentation for Importing Visualization Modules.

### DIFF
--- a/code_doc_autogen.py
+++ b/code_doc_autogen.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # -*- coding: utf-8 -*-
 # Copyright (c) 2019 Uber Technologies, Inc.
 #
@@ -106,6 +108,14 @@ PAGES = [
     },
     {
         "page": "user_guide/api/visualization.md",
+        "module_docstring": """
+        In order to use functions in this module, import `visualize` as follows:
+
+        ```python
+        import ludwig
+        from ludwig import visualize
+        ```
+        """,
         "functions": [
             learning_curves,
             compare_performance,
@@ -574,6 +584,9 @@ if __name__ == "__main__":
 
         if functions:
             blocks.append("# Module functions\n")
+            module_docstring: str | None = page_data.get("module_docstring")
+            if module_docstring:
+                blocks.append(process_docstring(module_docstring))
 
         for function in functions:
             blocks.append(render_function(function, _method=False))

--- a/code_doc_autogen.py
+++ b/code_doc_autogen.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 # -*- coding: utf-8 -*-
 # Copyright (c) 2019 Uber Technologies, Inc.
 #
@@ -21,6 +19,8 @@ Documentation Generator
 This code is a modified and adapted version of Keras' code_doc_autogen.py
 https://github.com/keras-team/keras-autodoc/blob/master/keras_autodoc/autogen.py
 """
+
+from __future__ import annotations
 
 import inspect
 import os

--- a/docs/developer_guide/contributing.md
+++ b/docs/developer_guide/contributing.md
@@ -8,7 +8,7 @@ It also helps us if you spread the word: reference the library from blog posts o
 projects it made possible, shout out on Twitter every time it has helped you, or simply star the
 repo to say "thank you".
 
-Check out the official [Ludwig docs](https://ludwig-ai.github.io/ludwig-docs/) to get oriented
+Check out the official [ludwig docs](https://ludwig-ai.github.io/ludwig-docs/) to get oriented
 around the codebase, and join the community!
 
 ## Open Issues

--- a/docs/user_guide/api/LudwigModel.md
+++ b/docs/user_guide/api/LudwigModel.md
@@ -413,6 +413,30 @@ For more context: https://discuss.pytorch.org/t/how-can-we-release-gpu-memory-ca
 
 
 ---
+## generate
+
+
+```python
+generate(
+  input_strings,
+  generation_config=None,
+  streaming=False
+)
+```
+
+
+A simple generate() method that directly uses the underlying transformers library to generate text.
+
+Args:
+input_strings (Union[str, List[str]]): Input text or list of texts to generate from.
+generation_config (Optional[dict]): Configuration for text generation.
+streaming (Optional[bool]): If True, enable streaming output.
+
+Returns:
+Union[str, List[str]]: Generated text or list of generated texts.
+
+
+---
 ## is_merge_and_unload_set
 
 
@@ -699,6 +723,32 @@ __Return__
 
 - __return__ ( `None): `None`
  
+
+---
+## save_dequantized_base_model
+
+
+```python
+save_dequantized_base_model(
+  save_path
+)
+```
+
+
+Upscales quantized weights of a model to fp16 and saves the result in a specified folder.
+
+Args:
+save_path (str): The path to the folder where the upscaled model weights will be saved.
+
+Raises:
+ValueError:
+If the model type is not 'llm' or if quantization is not enabled or the number of bits is not 4 or 8.
+RuntimeError:
+If no GPU is available, as GPU is required for quantized models.
+
+Returns:
+None
+
 
 ---
 ## save_torchscript

--- a/docs/user_guide/api/visualization.md
+++ b/docs/user_guide/api/visualization.md
@@ -4,6 +4,16 @@
 
 ---
 
+
+In order to use functions in this module, import `visualize` as follows:
+
+```python
+import ludwig
+from ludwig import visualize
+```
+
+---
+
 ## learning_curves
 
 


### PR DESCRIPTION
### Scope
This change provides the appropriate solution to the Issue [Unable to create visualizations using Python API](https://github.com/ludwig-ai/ludwig/issues/3922), which was reported in the Ludwig repository.  The appropriate solution is to provide the documentation on how to import the relevant modules.  This is a cleaner approach than adding imports into the top-level `__init__.py` in the Ludwig codebase.  The solution augments the automatic documentation mechanism by enabling it to include module-level docstrings.  /cc @w4nderlust @sanjaydasgupta