### PR TITLE
[MAINTENANCE] Replace Slack links with Discord links.

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -1,10 +1,9 @@
 # Chat
 
-We use Slack as a chat solution for allowing both Ludwig users and developers to
+We use Discord as a community solution for allowing both Ludwig users and developers to
 interact in a timely, more synchronous way.
 
-[Click here](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ)
-to receive an invitation.
+[Click here](https://discord.gg/CBgdrGnZjy) to join (we ask that you provide your email address).
 
 # Forum
 

--- a/docs/configuration/features/audio_features.md
+++ b/docs/configuration/features/audio_features.md
@@ -54,4 +54,4 @@ Encoder type and encoder parameters can also be defined once and applied to all 
 There are no audio decoders at the moment.
 
 If this unlocks an interesting use case for your application, please file a GitHub Issue or ping the
-[Ludwig Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ).
+[Community Discord](https://discord.gg/CBgdrGnZjy).

--- a/docs/configuration/features/time_series_features.md
+++ b/docs/configuration/features/time_series_features.md
@@ -63,4 +63,4 @@ Parameters:
 There are no time series decoders at the moment.
 
 If this would unlock an interesting use case for your application, please file a GitHub Issue or ping the
-[Ludwig Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ).
+[Community Discord](https://discord.gg/CBgdrGnZjy).

--- a/docs/developer_guide/contributing.md
+++ b/docs/developer_guide/contributing.md
@@ -5,7 +5,7 @@ way to help the community. Answering questions, helping others, reaching out and
 documentation are immensely valuable contributions as well.
 
 It also helps us if you spread the word: reference the library from blog posts on the awesome
-projects it made possible, shout out on Twitter every time it has helped you, or simply star the
+projects it made possible, shout out on X every time it has helped you, or simply star the
 repo to say "thank you".
 
 Check out the official [ludwig docs](https://ludwig-ai.github.io/ludwig-docs/) to get oriented
@@ -96,8 +96,7 @@ Work on your self-assigned issue and eventually create a Pull Request.
    To do that, edit the file `requirements_extra.txt` and comment out the line that begins with `horovod`.  After that,
    please execute the long `pip install` command given in the previous step.  With these work-around provisions, your
    installation should run to completion successfully.  If you are still having difficulty, please reach out with the
-   specifics of your environment in the Ludwig Community
-   [Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ).
+   specifics of your environment in our Discord Community [Discord](https://discord.gg/CBgdrGnZjy).
 
 1. Develop features on your branch.
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,6 +1,6 @@
 💡 Hands-on examples are the best way to learn about a new framework.
 
-Here, you'll find several examples of how to build models with Ludwig for a variety of tasks with LLMs, neural networks, and tree-based models. We provide sample datasets, commands, scripts, and Colab notebooks. Please [reach out](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ) if you have any questions!
+Here, you'll find several examples of how to build models with Ludwig for a variety of tasks with LLMs, neural networks, and tree-based models. We provide sample datasets, commands, scripts, and Colab notebooks. Please [reach out](https://discord.gg/CBgdrGnZjy) if you have any questions!
 
 💬 The **LLMs** section gives a broad overview of the full breadth of Ludwig's LLM capabilities like [zero-shot batch inference](https://ludwig.ai/latest/examples/llms/llm_zero_shot_text_generation/) and [fine-tuning Llama-2-7b](https://ludwig.ai/latest/examples/llms/llm_finetuning/).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,11 +6,11 @@ Smaller feature requests are tracked in [Github Issues](https://github.com/ludwi
 
 We try our best to keep these up to date, but if there's a specific feature or
 model you are interested in, feel free to ping the
-[Ludwig Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ).
+[Community Discord](https://discord.gg/CBgdrGnZjy).
 
 # How can I help?
 
-Join the [Ludwig Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ)!
+Join the [Community Discord](https://discord.gg/CBgdrGnZjy)!
 Sometimes we'll organize community fixit, documentation, and bug bash efforts,
 or consider taking on an [easy bug](https://github.com/ludwig-ai/ludwig/labels/easy)
 to start.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,8 +24,10 @@
 </a>
 </p>
 
-> \[!IMPORTANT\]
-> Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
+---
+**IMPORTANT**
+
+Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,8 @@
 <a href="https://github.com/ludwig-ai/ludwig/blob/master/LICENSE" target="_blank" style="text-decoration: none;">
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="license">
 </a>
-<a href="https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ" target="_blank" style="text-decoration: none;">
-    <img src="https://img.shields.io/badge/slack-chat-green.svg?logo=slack" alt="slack">
+<a href="https://discord.gg/CBgdrGnZjy" target="_blank" style="text-decoration: none;">
+    <img src="https://dcbadge.vercel.app/api/server/CBgdrGnZjy?style=flat&theme=discord-inverted" alt="Discord">
 </a>
 </p>
 
@@ -184,7 +184,7 @@ ludwig train --config model.yaml --dataset rotten_tomatoes.csv
 
 **Happy modeling**
 
-Try applying Ludwig to your data. [Reach out](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ)
+Try applying Ludwig to your data. [Reach out](https://discord.gg/CBgdrGnZjy)
 if you have any questions.
 
 # ❓ Why you should use Ludwig
@@ -304,7 +304,7 @@ Read our publications on [Ludwig](https://arxiv.org/pdf/1909.07930.pdf), [declar
 Learn more about [how Ludwig works](./user_guide/how_ludwig_works/), [how to get started](./getting_started/), and work through more [examples](./examples/).
 
 If you are interested in [contributing](./developer_guide/contributing.md), have questions, comments, or thoughts to share, or if you just want to be in the
-know, please consider [joining the Ludwig Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ) and follow us on [Twitter](https://twitter.com/ludwig_ai)!
+know, please consider [joining our Community Discord](https://discord.gg/CBgdrGnZjy) and follow us on [X](https://twitter.com/ludwig_ai)!
 
 # 🤝 Join the community to build Ludwig with us
 
@@ -318,7 +318,7 @@ more accessible and feature rich framework for everyone to use!
 
 # 👋 Getting Involved
 
-- [Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ)
-- [Twitter](https://twitter.com/ludwig_ai)
+- [Discord](https://discord.gg/CBgdrGnZjy)
+- [X](https://twitter.com/ludwig_ai)
 - [Medium](https://medium.com/ludwig-ai)
 - [GitHub Issues](https://github.com/ludwig-ai/ludwig/issues)

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,9 @@
 </a>
 </p>
 
+> \[!IMPORTANT\]
+> Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
+
 ---
 
 # 📖 What is Ludwig?
@@ -42,6 +45,9 @@ Ludwig is hosted by the
 [Linux Foundation AI & Data](https://lfaidata.foundation/).
 
 ![img](https://raw.githubusercontent.com/ludwig-ai/ludwig-docs/master/docs/images/ludwig_legos_unanimated.gif)
+
+[!IMPORTANT]
+Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
 
 # 💾 Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@
 ---
 **IMPORTANT**
 
-Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
+## :exclamation: The Ludwig community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us there!
 
 ---
 

--- a/docs/user_guide/api/LudwigModel.md
+++ b/docs/user_guide/api/LudwigModel.md
@@ -413,30 +413,6 @@ For more context: https://discuss.pytorch.org/t/how-can-we-release-gpu-memory-ca
 
 
 ---
-## generate
-
-
-```python
-generate(
-  input_strings,
-  generation_config=None,
-  streaming=False
-)
-```
-
-
-A simple generate() method that directly uses the underlying transformers library to generate text.
-
-Args:
-input_strings (Union[str, List[str]]): Input text or list of texts to generate from.
-generation_config (Optional[dict]): Configuration for text generation.
-streaming (Optional[bool]): If True, enable streaming output.
-
-Returns:
-Union[str, List[str]]: Generated text or list of generated texts.
-
-
----
 ## is_merge_and_unload_set
 
 
@@ -466,8 +442,7 @@ load(
   gpus=None,
   gpu_memory_limit=None,
   allow_parallel_threads=True,
-  callbacks=None,
-  from_checkpoint=False
+  callbacks=None
 )
 ```
 
@@ -495,9 +470,6 @@ determinism.
 - __callbacks__ (list, default: `None`): a list of
 `ludwig.callbacks.Callback` objects that provide hooks into the
 Ludwig pipeline.
-- __from_checkpoint__ (bool, default: `False`): if `True`, the model
-will be loaded from the latest checkpoint (training_checkpoints/)
-instead of the final model weights.
 
 __Return__
 
@@ -519,8 +491,7 @@ ludwig_model = LudwigModel.load(model_dir)
 
 ```python
 load_weights(
-  model_dir,
-  from_checkpoint=False
+  model_dir
 )
 ```
 
@@ -531,9 +502,6 @@ __Inputs__
 
 - __model_dir__ (str): filepath string to location of a pre-trained
 model
-- __from_checkpoint__ (bool, default: `False`): if `True`, the model
-will be loaded from the latest checkpoint (training_checkpoints/)
-instead of the final model weights.
 
 __Return__
 
@@ -731,32 +699,6 @@ __Return__
 
 - __return__ ( `None): `None`
  
-
----
-## save_dequantized_base_model
-
-
-```python
-save_dequantized_base_model(
-  save_path
-)
-```
-
-
-Upscales quantized weights of a model to fp16 and saves the result in a specified folder.
-
-Args:
-save_path (str): The path to the folder where the upscaled model weights will be saved.
-
-Raises:
-ValueError:
-If the model type is not 'llm' or if quantization is not enabled or the number of bits is not 4 or 8.
-RuntimeError:
-If no GPU is available, as GPU is required for quantized models.
-
-Returns:
-None
-
 
 ---
 ## save_torchscript


### PR DESCRIPTION
### Scope
* All Slack links are replaced with links referring to the "Predibase / LoRAX / Ludwig" community on Discord.
* There is a sibling code repository [pull request](https://github.com/ludwig-ai/ludwig/pull/3988).
