### PR TITLE
Fixed a minor misinformation on how to use --config and --config_str.

### DIFF
--- a/docs/user_guide/command_line_interface.md
+++ b/docs/user_guide/command_line_interface.md
@@ -199,7 +199,7 @@ Finally the `--logging_level` argument lets you set the amount of logging that y
 Example:
 
 ```bash
-ludwig train --dataset reuters-allcats.csv --config "{input_features: [{name: text, type: text, encoder: {type: parallel_cnn}}], output_features: [{name: class, type: category}]}"
+ludwig train --dataset reuters-allcats.csv --config_str "{input_features: [{name: text, type: text, encoder: {type: parallel_cnn}}], output_features: [{name: class, type: category}]}"
 ```
 
 # predict
@@ -487,7 +487,7 @@ The output directory will contain the outputs both commands produce.
 Example:
 
 ```bash
-ludwig experiment --dataset reuters-allcats.csv --config "{input_features: [{name: text, type: text, encoder: {type: parallel_cnn}}], output_features: [{name: class, type: category}]}"
+ludwig experiment --dataset reuters-allcats.csv --config_str "{input_features: [{name: text, type: text, encoder: {type: parallel_cnn}}], output_features: [{name: class, type: category}]}"
 ```
 
 # hyperopt

--- a/main.py
+++ b/main.py
@@ -246,7 +246,7 @@ def define_env(env):
                 ' :octicons-bookmark-fill-24:{ title="High impact parameter" }'
             )
 
-        s = f"- **`{ name }`** {default_str}{impact_badge}: { field.metadata['description'] }"
+        s = f"- **`{name}`** {default_str}{impact_badge}: {field.metadata['description']}"
         if field.validate is not None and hasattr(field.validate, "choices"):
             options = ", ".join(
                 [f"`{dump_value(opt)}`" for opt in field.validate.choices]


### PR DESCRIPTION
The docs for the CLI commands have some examples on how to use a config string. The CLI argument --config was falsely used instead of --config_str.