### PR TITLE
Docs: Phase 3 - export and serving modernization

### DIFF
--- a/docs/user_guide/command_line_interface.md
+++ b/docs/user_guide/command_line_interface.md
@@ -16,8 +16,7 @@ Ludwig provides several functions through its command line interface.
 | [`collect_summary`](#collect_summary)         | Prints names of weights and layers activations to use with other collect commands |
 | [`collect_weights`](#collect_weights)         | Collects tensors containing a pretrained model weights                            |
 | [`collect_activations`](#collect_activations) | Collects tensors for each datapoint using a pretrained model                      |
-| [`export_torchscript`](#export_torchscript)   | Exports Ludwig models to Torchscript                                              |
-| [`export_carton`](#export_carton)             | Exports Ludwig models to Carton                                                   |
+| [`export_model`](#export_model)               | Exports Ludwig models to SafeTensors, torch.export, or ONNX                      |
 | [`export_mlflow`](#export_mlflow)             | Exports Ludwig models to MLflow                                                   |
 | [`preprocess`](#preprocess)                   | Preprocess data and saves it into cached format                                   |
 | [`synthesize_dataset`](#synthesize_dataset)   | Creates synthetic data for testing purposes                                       |
@@ -936,79 +935,32 @@ The collect-specific arguments, `--model_path`, `--tensors` and
 `--output_directory`, are the same used in [collect_weights](#collect_weights),
 you can refer to that section for an explanation.
 
-# export_torchscript
+# export_model
 
-Exports a pre-trained model to Torch's `torchscript` format.
-
-```bash
-ludwig export_torchscript [options]
-```
-
-or with:
+Exports a trained Ludwig model to SafeTensors, torch.export, or ONNX format.
 
 ```bash
-python -m ludwig.export torchscript [options]
+ludwig export_model [options]
 ```
 
 These are the available arguments:
 
 ```
-usage: ludwig export_torchscript [options]
-
-This script loads a pretrained model and saves it as torchscript.
+usage: ludwig export_model [options]
 
 optional arguments:
   -h, --help            show this help message and exit
   -m MODEL_PATH, --model_path MODEL_PATH
-                        model to load
-  -mo, --model_only     Script and export the model only.
-  -d DEVICE, --device DEVICE
-                        Device to use for torchscript tracing (e.g. "cuda" or "cpu"). Ideally, this is the same as the device used
-                        when the model is loaded.
-  -op OUTPUT_PATH, --output_path OUTPUT_PATH
-                        path where to save the export model. If not specified, defaults to model_path.
+                        path to the trained model
+  -o OUTPUT_PATH, --output_path OUTPUT_PATH
+                        output directory for the exported model
+  -f {safetensors,torch_export,onnx}, --format {safetensors,torch_export,onnx}
+                        export format (default: safetensors)
   -l {critical,error,warning,info,debug,notset}, --logging_level {critical,error,warning,info,debug,notset}
                         the level of logging to use
 ```
 
-For more information, see [TorchScript Export](model_export.md#torchscript-export)
-
-# export_carton
-
-A Ludwig model can be exported as a [Carton](https://carton.run/), which allows it to be run from several programming languages (including C, C++, Rust, and more).
-
-In order to export a Ludwig model to Carton, first make sure the `cartonml` package is installed in your environment (`pip install cartonml-nightly`), then run the following command:
-
-```bash
-ludwig export_carton [options]
-```
-
-or with:
-
-```bash
-python -m ludwig.export carton [options]
-```
-
-These are the available arguments:
-
-```
-usage: ludwig export_carton [options]
-
-This script loads a pretrained model and saves it as a Carton.
-
-options:
-  -h, --help            show this help message and exit
-  -m MODEL_PATH, --model_path MODEL_PATH
-                        model to load
-  -mn MODEL_NAME, --model_name MODEL_NAME
-                        model name
-  -od OUTPUT_PATH, --output_path OUTPUT_PATH
-                        path where to save the export model
-  -l {critical,error,warning,info,debug,notset}, --logging_level {critical,error,warning,info,debug,notset}
-                        the level of logging to use
-```
-
-For more information, see [Carton Export](model_export.md#carton-export)
+For more information, see [Model Export](model_export.md).
 
 # export_mlflow
 

--- a/docs/user_guide/model_export.md
+++ b/docs/user_guide/model_export.md
@@ -1,204 +1,85 @@
 # Exporting Ludwig Models
 
-There are a number of ways to export models in Ludwig.
+Ludwig supports exporting trained models in several formats for deployment.
 
-## TorchScript Export
+## Export Formats
 
-A subset of Ludwig Models can be exported to Torchscript end-to-end. This means
-that, in addition to the model itself, the preprocessing and postprocessing steps can be exported to TorchScript as well, ensuring that the model can be used for inference in a production environment out-of-the-box.
+### SafeTensors (Default)
 
-To get started, simply run the [`export_torchscript`](command_line_interface.md#export_torchscript) command:
+SafeTensors is the default format for Ludwig model weights. It provides secure, zero-copy serialization.
 
-```
-ludwig export_torchscript -m=results/experiment_run/model
-```
-
-As long as `--model_only` is not specified, then three files are output by this command. The most important are `inference_preprocessor.pt`, `inference_predictor_<DEVICE>.pt`, and `inference_postprocessor.pt`.
-
-The `inference_preprocessor.pt` file contains the preprocessor, which is a `torch.nn.Module` that takes in a dictionary of raw data and outputs a dictionary of tensors. The `inference_predictor_<DEVICE>.pt` file contains the predictor, which is a `torch.nn.Module` that takes in a dictionary of tensors and outputs a dictionary of tensors. The `inference_postprocessor.pt` file contains the postprocessor, which is a `torch.nn.Module` that takes in a dictionary of tensors and outputs a dictionary of postprocessed data containing the same keys as the Ludwig `predict` command DataFrame output. These files can each be loaded separately (and on separate devices) to run inference in a staged manner. This can be particularly useful with a tool like [NVIDIA Triton](https://developer.nvidia.com/nvidia-triton-inference-server), which can be used to manage each stage of the pipeline independently.
-
-You can get started using these modules immediately by loading them with `torch.jit.load`:
-
-```
->>> import torch
->>> preprocessor = torch.jit.load("model/inference_preprocessor.pt")
->>> predictor = torch.jit.load("model/inference_predictor_cpu.pt")
->>> postprocessor = torch.jit.load("model/inference_postprocessor.pt")
+```python
+model = LudwigModel.load("results/experiment_run/model")
+model.export_model("exported/", format="safetensors")
 ```
 
-Once you've done this, you can pass in raw data in the form of a dictionary and get back predictions in the form of a dictionary:
-
-```
->>> raw_data = {
-    'text_feature': ['This is a test.'],
-    'category_feature': ['cat1', 'cat2'],
-    'numerical_feature': [1.0, 2.0],
-    'vector_feature': [[1.0, 2.0], [3.0, 4.0]],
-}
->>> preprocessed_data = preprocessor(raw_data)
->>> predictions = predictor(preprocessed_data)
->>> postprocessed_data = postprocessor(predictions)
->>> postprocessed_data
-{
-    'probabilities': [[0.8, 0.2]],
-    'predictions': ['class1', 'class2'],
-}
+CLI:
+```bash
+ludwig export_model -m results/experiment_run/model -o exported/ -f safetensors
 ```
 
-If you have your data stored in a DataFrame, you can use the `to_inference_module_input_from_dataframe` function to convert it to the correct format:
+### torch.export
 
-```
->>> import pandas as pd
->>> from ludwig.utils.inference_utils import to_inference_module_input_from_dataframe
+`torch.export` is the official replacement for TorchScript (deprecated in PyTorch 2.9). It captures the full computation graph as an `ExportedProgram` at the ATen operator level.
 
->>> df = pd.read_csv('test.csv')
->>> raw_data = to_inference_module_input_from_dataframe(df)
->>> raw_data
-{
-    'text_feature': ['This is a test.'],
-    'category_feature': ['cat1', 'cat2'],
-    'numerical_feature': [1.0, 2.0],
-    'vector_feature': [[1.0, 2.0], [3.0, 4.0]],
-}
+```python
+model = LudwigModel.load("results/experiment_run/model")
+model.export_model("exported/", format="torch_export")
 ```
 
-### Using the InferenceModule class
+The exported `.pt2` file can be:
 
-For convenience, we've provided a wrapper class called `InferenceModule` that can be used to load and use the exported model. The `InferenceModule` class is a subclass of `torch.nn.Module` and can be used in the same way. The `InferenceModule` class can be used to load the preprocessor, predictor, and postprocessor in a single step:
+- Loaded back via `torch.export.load()`
+- Compiled with `torch.compile()` for runtime optimization
+- Used as input to the dynamo-based ONNX exporter
+- Deployed via ExecuTorch for on-device inference
 
-```
->>> from ludwig.models.inference import InferenceModule
->>> inference_module = InferenceModule.from_directory('model/')
->>> raw_data = {...}
->>> preprocessed_data = inference_module.preprocessor_forward(raw_data)
->>> predictions = inference_module.predictor_forward(preprocessed_data)
->>> postprocessed_data = inference_module.postprocessor_forward(predictions)
-```
-
-You can also call the preprocessor, predictor, and postprocessor separately:
-
-```
->>> inference_module.preprocessor_forward(raw_data)
-{...}
+CLI:
+```bash
+ludwig export_model -m results/experiment_run/model -o exported/ -f torch_export
 ```
 
-You can also use the `InferenceModule.predict` method to input a DataFrame and output a DataFrame, similar to how you would with the `LudwigModel.predict` method:
+### ONNX
 
-```
->>> input_df = pd.read_csv('test.csv')
->>> output_df = inference_module.predict(input_df)
-```
+ONNX export uses the dynamo-based exporter (`torch.onnx.export(dynamo=True)`) for cross-platform deployment.
 
-Finally, you can convert the `InferenceModule` to TorchScript if you need a monolithic artifact for inference. Note that you can still call the `InferenceModule.preprocessor_forward`, `InferenceModule.predictor_forward`, and `InferenceModule.postprocessor_forward` methods, but `InferenceModule.predict` will no longer work after this conversion.
-
-```
->>> scripted_module = torch.jit.script(inference_module)
->>> raw_data = {...}
->>> scripted_module(raw_data)
-{...}
->>> input_df = pd.read_csv('test.csv')
->>> scripted_module.predict(input_df)  # Will fail
+```python
+model = LudwigModel.load("results/experiment_run/model")
+model.export_model("exported/", format="onnx")
 ```
 
-### Current Limitations
+The exported ONNX model can be loaded with ONNX Runtime:
 
-TorchScript only implements a subset of Python libraries. This means that there are a few of Ludwig's preprocessing steps that are not supported.
-
-#### Image and Audio Features
-
-If you are using the preprocessor module directly or using the `forward` method of the `InferenceModule` module, loading `image` and `audio` files from filepaths is not supported. Instead, one has to load the data as either a batched tensor or a List of tensors ahead of passing it in to the module.
-
-If you are using the `predict` method of the `InferenceModule` module, then filepath strings will be loaded for you.
-
-#### Date Features
-
-TorchScript does not implement the `datetime` module, which means that `date` features cannot be parsed from string.
-
-If you are using the preprocessor module directly or using the `forward` method of the `InferenceModule` module, a vector of integers representing the date must be passed in. Given a `datetime_obj`, the following code can be used to generate the vector:
-
-```
-def create_vector_from_datetime_obj(datetime_obj):
-    yearday = datetime_obj.toordinal() - date(datetime_obj.year, 1, 1).toordinal() + 1
-
-    midnight = datetime_obj.replace(hour=0, minute=0, second=0, microsecond=0)
-    second_of_day = (datetime_obj - midnight).seconds
-
-    return [
-        datetime_obj.year,
-        datetime_obj.month,
-        datetime_obj.day,
-        datetime_obj.weekday(),
-        yearday,
-        datetime_obj.hour,
-        datetime_obj.minute,
-        datetime_obj.second,
-        second_of_day,
-    ]
+```python
+import onnxruntime as ort
+session = ort.InferenceSession("exported/model.onnx")
 ```
 
-This function is also available in the `ludwig.utils.date_utils` module for convenience.
-
-If you are using the `predict` method of the `InferenceModule` module, then date strings will be featurized for you.
-
-#### GPU Support
-
-Input features fed in as strings can only be preprocessed on CPU. In Ludwig, these would be the following features:
-
-- `binary`
-- `category`
-- `set`
-- `sequence`
-- `text`
-- `vector`
-- `bag`
-- `timeseries`
-
-If you are using the preprocessor module directly or using the `forward` method of the `InferenceModule` module, then the user can pass in `binary`, `vector`, and `time series` features as tensors to preprocess them on the GPU.
-
-If you are using the `predict` method of the `InferenceModule` module, then all of the above features will be cast first to string and then preprocessed on CPU.
-
-#### NaN Handling
-
-For the majority of features, NaNs are handled by the preprocessor in the same way that they are handled by the original Ludwig Model. The exceptions are the following features:
-
-- `image`
-- `audio`
-- `date`
-- `vector`
-
-#### HuggingFace Models
-
-HuggingFace models are not yet supported for TorchScript export, though we are working on it!
-
-## Carton Export
-
-[Carton](https://carton.run/) is a library that allows users to efficiently run ML models from several programming languages (including C, C++, Rust, and more).
-
-A subset of Ludwig Models can be exported to Carton. In addition to the model itself, the preprocessing and postprocessing steps are included in the exported model as well, ensuring that the model can be used for inference in a production environment out-of-the-box.
-
-To get started, simply run the [`export_carton`](command_line_interface.md#export_carton) command:
-
-```
-ludwig export_carton -m=results/experiment_run/model
-```
-This will produce a file that can be loaded by Carton from any supported programming language.
-
-For example, from Python, you can load and run the model as follows:
-
-```py
-import cartonml as carton
-
-async def main():
-    model = await carton.load("/path/to/model.carton")
-    output = await model.infer({
-        "x": np.zeros(5)
-    })
+CLI:
+```bash
+ludwig export_model -m results/experiment_run/model -o exported/ -f onnx
 ```
 
-See the [Carton quickstart guide](https://carton.run/quickstart) for usage from other programming languages.
+### MLflow
 
-## Triton Export
+Export to MLflow format for model registry and deployment:
 
-Coming soon...
+```bash
+ludwig export_mlflow -m results/experiment_run/model -o mlflow_model/
+```
 
-## MLFlow Export
+See [Integrations](integrations.md) for details on the MLflow integration.
+
+## Loading Exported Models
+
+The `load_exported_model` utility auto-detects the format:
+
+```python
+from ludwig.utils.model_export import load_exported_model
+
+# torch.export format
+program = load_exported_model("exported/model.pt2")
+
+# ONNX format (requires onnxruntime)
+session = load_exported_model("exported/model.onnx")
+```

--- a/docs/user_guide/serving.md
+++ b/docs/user_guide/serving.md
@@ -1,253 +1,143 @@
 # Serving Ludwig Models
 
-Ludwig models can be served using the [serve command](command_line_interface.md#serve).
+Ludwig provides two serving options: a general-purpose REST API for ECD models and an OpenAI-compatible server for LLMs.
+
+## REST API Server
+
+### Starting the server
 
 ```bash
 ludwig serve --model_path=/path/to/model
 ```
 
-The command will spawn a Rest API using the [FastAPI](https://fastapi.tiangolo.com/) library.
+This spawns a FastAPI server with the following endpoints:
 
-This API has two endpoints: `predict` and `predict_batch`. `predict` should be used to obtain predictions for individual
-examples, while `predict_batch` should be used to obtain predictions for an a batch of examples.
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/` | GET | Health check |
+| `/info` | GET | Model metadata (input/output features, model type) |
+| `/predict` | POST | Single-record prediction |
+| `/batch_predict` | POST | Batch prediction |
+| `/metrics` | GET | Prometheus metrics (if prometheus_client is installed) |
 
-Inputs sent to the REST API should be consistent with the feature names and types used to train the model. The output
-structure from the REST API depends on the model's output features and their data types.
+### Single prediction
 
-# REST Endpoints
-
-## predict
-
-### Input format
-
-For each input of the model, the predict endpoint expects a field with a name.
-For instance, a model trained with an input text field named `english_text` would expect a POST like:
+Send a JSON body with feature values:
 
 ```bash
-curl http://0.0.0.0:8000/predict -X POST -F 'english_text=words to be translated'
+curl http://0.0.0.0:8000/predict -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"text_feature": "words to predict", "number_feature": 42}'
 ```
 
-If the model was trained with an input image field, it will instead expects a POST with a file, like:
+Response:
+```json
+{
+  "output_predictions": "class_a",
+  "output_probabilities_class_a": 0.82,
+  "output_probabilities_class_b": 0.18,
+  "output_probability": 0.82
+}
+```
+
+### Batch prediction
+
+Send a JSON array:
 
 ```bash
-curl http://0.0.0.0:8000/predict -X POST -F 'image=@path_to_image/example.png'
+curl http://0.0.0.0:8000/batch_predict -X POST \
+  -H "Content-Type: application/json" \
+  -d '[{"text": "first example"}, {"text": "second example"}]'
 ```
 
-A model with both a text and an image field will expect a POST like:
+### Features
+
+- **Auto-generated Pydantic schemas** from model config for request/response validation
+- **Prometheus metrics** at `/metrics` with request count and latency histograms
+- **Structured logging** of every request (method, path, status, duration, client)
+- **Configurable timeout** for long predictions (returns HTTP 504 on timeout)
+- **Model hot-swap** via dependency injection
+
+### Python API
+
+```python
+from ludwig.serve_v2 import create_app
+
+app = create_app(model_path="path/to/model", timeout_seconds=300)
+# Use with uvicorn, gunicorn, or any ASGI server
+```
+
+## LLM Serving with vLLM
+
+For LLM models, Ludwig provides an OpenAI-compatible serving backend powered by vLLM with PagedAttention and continuous batching.
+
+### Prerequisites
 
 ```bash
-curl http://0.0.0.0:8000/predict -X POST -F 'text=mixed together with' -F 'image=@path_to_image/example.png'
+pip install vllm
 ```
 
-### Output format
+### Starting the server
 
- The response is a JSON dictionary with keys prefixed by the names of the model's output features.
+```python
+from ludwig.serve_vllm import run_vllm_server
 
-For binary outputs, the JSON structure returned by the REST API is the following:
-
-```json
-{
-   "NAME_predictions": false,
-   "NAME_probabilities_False": 0.76,
-   "NAME_probabilities_True": 0.24,
-   "NAME_probability": 0.76
-}
+run_vllm_server(
+    model_path="path/to/ludwig/model",
+    host="0.0.0.0",
+    port=8000,
+    gpu_memory_utilization=0.9,
+)
 ```
 
-For number outputs, the JSON structure returned by the REST API is the following:
+### OpenAI-compatible endpoints
 
-```json
-{"NAME_predictions": 0.381}
-```
-
-For categorical outputs, the JSON structure returned by the REST API is the following:
-
-```json
-{
-   "NAME_predictions": "CLASSNAMEK",
-   "NAME_probability": 0.62,
-   "NAME_probabilities_CLASSNAME1": 0.099,
-   "NAME_probabilities_CLASSNAME2": 0.095,
-   ...
-   "NAME_probabilities_CLASSNAMEN": 0.077
-}
-```
-
-For set outputs, the JSON structure returned by the REST API is the following:
-
-```json
-{
-   "NAME_predictions":[
-      "CLASSNAMEI",
-      "CLASSNAMEJ",
-      "CLASSNAMEK"
-   ],
-   "NAME_probabilities_CLASSNAME1":0.490,
-   "NAME_probabilities_CLASSNAME2":0.245,
-   ...
-   "NAME_probabilities_CLASSNAMEN":0.341,
-   "NAME_probability":[
-      0.53,
-      0.62,
-      0.95
-   ]
-}
-```
-
-For sequence outputs, the JSON structure returned by the REST API is the following:
-
-```json
-{
-   "NAME_predictions":[
-      "TOKEN1",
-      "TOKEN2",
-      "TOKEN3"
-   ],
-   "NAME_last_predictions": "TOKEN3",
-   "NAME_probabilities":[
-      0.106,
-      0.122,
-      0.118,
-      0.133
-   ],
-   "NAME_probability": -6.4765729904174805
-}
-```
-
-For text outputs, the JSON structure returned by the REST API is the same as for sequences.
-
-## batch_predict
-
-### Input format
-
-You can also make a POST request on the /batch_predict endpoint to run inference on multiple samples at once.
-
-Requests must be submitted as form data, with one of fields being `dataset`: a JSON encoded string representation of the
-data to be predicted.
-
-The dataset JSON string is expected to be in the Pandas `split` format to reduce payload size.
-This format divides the dataset into three parts:
-
-- `columns`: `List[str]`
-- `index` (optional): `List[Union[str, int]]`
-- `data`: `List[List[object]]`
-
-Additional form fields can be used to provide file resources like images that are referenced within the dataset.
-
-An example of batch prediction:
+The vLLM server exposes the same API as OpenAI's API:
 
 ```bash
-curl http://0.0.0.0:8000/batch_predict -X POST -F 'dataset={"columns": ["a", "b"], "data": [[1, 2], [3, 4]]}'
+# Chat completions
+curl http://localhost:8000/v1/chat/completions -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ludwig-llm",
+    "messages": [{"role": "user", "content": "What is machine learning?"}],
+    "temperature": 0.7,
+    "max_tokens": 256
+  }'
+
+# Text completions
+curl http://localhost:8000/v1/completions -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ludwig-llm",
+    "prompt": "Machine learning is",
+    "max_tokens": 100
+  }'
+
+# List models
+curl http://localhost:8000/v1/models
 ```
 
-### Output format
+### Configuration
 
-The response is a JSON dictionary with keys prefixed by the names of the model's output features.
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `model_path` | required | Path to Ludwig model or HuggingFace model ID |
+| `gpu_memory_utilization` | 0.9 | Fraction of GPU memory to use |
+| `tensor_parallel_size` | 1 | Number of GPUs for tensor parallelism |
+| `quantization` | None | Quantization method: awq, gptq, fp8 |
+| `max_model_len` | auto | Maximum sequence length |
 
-For binary outputs, the JSON structure returned by the REST API is the following:
+### Using with OpenAI Python client
 
-```json
-{
-   "index": [0, 1],
-   "columns": [
-      "NAME_predictions",
-      "NAME_probabilities_False",
-      "NAME_probabilities_True",
-      "NAME_probability"
-   ],
-   "data": [
-      [false, 0.768, 0.231, 0.768],
-      [true, 0.372, 0.627, 0.627]
-   ]
-}
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="ludwig-llm",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
 ```
-
-For number outputs, the JSON structure returned by the REST API is the following:
-
-```json
-{"index":[0, 1],"columns":["NAME_predictions"],"data":[[0.381],[0.202]]}
-```
-
-For categorical outputs, the JSON structure returned by the REST API is the following:
-
-```json
-{
-   "index": [0, 1],
-   "columns": [
-      "NAME_predictions",
-      "NAME_probabilities_CLASSNAME1",
-      "NAME_probabilities_CLASSNAME2",
-      ...
-      "NAME_probabilities_CLASSNAMEN",
-      "NAME_probability"
-   ],
-   "data": [
-      ["CLASSNAMEK", 0.099, 0.095, ... 0.077, 0.623],
-      ["CLASSNAMEK", 0.092, 0.061, ... 0.084, 0.541]
-   ]
-}
-```
-
-For set outputs, the JSON structure returned by the REST API is the following:
-
-```json
-{
-   "index": [0, 1],
-   "columns": [
-      "NAME_predictions",
-      "NAME_probabilities_CLASSNAME1",
-      "NAME_probabilities_CLASSNAME2",
-      ...
-      "NAME_probabilities_CLASSNAMEK",
-      "NAME_probability"
-   ],
-   "data": [
-      [
-         ["CLASSNAMEI", "CLASSNAMEJ", "CLASSNAMEK"],
-         0.490,
-         0.453,
-         ...
-         0.500,
-         [0.53, 0.62, 0.95]
-      ],
-      [
-         ["CLASSNAMEM", "CLASSNAMEN", "CLASSNAMEO"],
-         0.481,
-         0.466,
-         ...
-         0.485,
-         [0.63, 0.72, 0.81]
-      ]
-   ]
-}
-```
-
-For sequence outputs, the JSON structure returned by the REST API is the following:
-
-```json
-{
-   "index": [0, 1],
-   "columns": [
-      "NAME_predictions",
-      "NAME_last_predictions",
-      "NAME_probabilities",
-      "NAME_probability"
-   ],
-   "data": [
-      [
-         ["TOKEN1", "TOKEN1", "TOKEN1"],
-         "TOKEN3",
-         [0.106, 0.122, … 0.083],
-         -6.476
-      ],
-      [
-         ["TOKEN4", "TOKEN5", "TOKEN6"],
-         "TOKEN6",
-         [0.108, 0.127, … 0.083],
-         -6.482
-      ]
-   ]
-}
-```
-
-For text outputs, the JSON structure returned by the REST API is the same as for sequences.


### PR DESCRIPTION
Updates documentation for Phase 3 changes:

- **model_export.md**: Complete rewrite. Removed TorchScript, Carton, and Triton sections. Added torch.export, ONNX (dynamo), SafeTensors, and load_exported_model documentation.
- **serving.md**: Complete rewrite. Added modernized REST API docs (Pydantic schemas, Prometheus metrics, structured logging, timeout handling). Added vLLM LLM serving section with OpenAI-compatible API examples.
- **command_line_interface.md**: Replaced export_torchscript and export_carton commands with export_model command.

Net: -277 lines (removed 433 lines of TorchScript docs, added 156 lines of modern export/serving docs).