### PR TITLE
Docs: cover Ludwig 0.14 trainer, decoder, loss, and serving additions

### DIFF
--- a/docs/configuration/features/category_features.md
+++ b/docs/configuration/features/category_features.md
@@ -178,7 +178,7 @@ the only supported loss type for category output features. See [Loss](#loss) for
 - **`top_k`** (default `3`): determines the parameter `k`, the number of categories to consider when computing the `top_k`
 measure. It computes accuracy but considering as a match if the true category appears in the first `k` predicted
 categories ranked by decoder's confidence.
-- **`decoder`** (default: `{"type": "classifier"}`): Decoder for the desired task. Options: `classifier`. See [Decoder](#decoders) for details.
+- **`decoder`** (default: `{"type": "classifier"}`): Decoder for the desired task. Options: `classifier`, `mlp_classifier`. See [Decoder](#decoders) for details.
 
 Decoder type and decoder parameters can also be defined once and applied to all category output features using the [Type-Global Decoder](../defaults.md#type-global-decoder) section.
 
@@ -192,6 +192,67 @@ Decoder type and decoder parameters can also be defined once and applied to all 
 Parameters:
 
 {{ render_fields(schema_class_to_fields(decoder, exclude=["type"]), details=details) }}
+
+### MLP Classifier
+
+`mlp_classifier` adds an explicit stack of hidden layers between the combiner output and the
+final projection. It is useful when the combiner itself is shallow (for example the `concat`
+combiner over tabular features) and the classification head needs more non-linear capacity.
+
+```yaml
+decoder:
+  type: mlp_classifier
+  num_fc_layers: 2
+  output_size: 512
+  activation: relu
+  dropout: 0.2
+```
+
+Setting `num_fc_layers: 0` is equivalent to the plain `classifier`.
+
+{% set decoder = get_decoder_schema("category", "mlp_classifier") %}
+{{ render_yaml(decoder, parent="decoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(decoder, exclude=["type"]), details=details) }}
+
+### Probability calibration (temperature scaling)
+
+Both `classifier` and `mlp_classifier` expose a `calibration` parameter. Set it to
+`temperature_scaling` to learn a single scalar temperature on the validation set that is
+applied as `logits / T` ([Guo et al., ICML 2017](https://arxiv.org/abs/1706.04599)).
+Temperature scaling never changes the argmax prediction; it only reshapes the probability
+distribution so that predicted confidences track empirical accuracy more closely.
+
+```yaml
+decoder:
+  type: classifier
+  calibration: temperature_scaling
+```
+
+Temperature scaling is run automatically at the end of training using the validation split.
+The learned temperature is serialized with the model and applied at inference.
+
+### Monte Carlo dropout uncertainty
+
+Both decoders also expose `mc_dropout_samples` ([Gal & Ghahramani, ICML 2016](https://arxiv.org/abs/1506.02142)).
+When set to a positive integer, Ludwig runs the decoder that many times at inference *with
+dropout enabled* and returns:
+
+- the mean predicted probabilities,
+- an additional `uncertainty` tensor that captures the variance across samples.
+
+```yaml
+decoder:
+  type: mlp_classifier
+  num_fc_layers: 2
+  dropout: 0.2
+  mc_dropout_samples: 20
+```
+
+MC dropout requires `dropout > 0` in the decoder; otherwise the repeated forward passes are
+identical and the uncertainty estimate is always zero.
 
 ## Loss
 

--- a/docs/configuration/features/image_features.md
+++ b/docs/configuration/features/image_features.md
@@ -592,7 +592,7 @@ augmentation:
 # Output Features
 
 Image features can be used when semantic segmentation needs to be performed.
-There is only one decoder available for image features: `unet`.
+Ludwig 0.14 exposes three segmentation decoders: `unet`, `segformer`, and `fpn`.
 
 Example image output feature using default parameters:
 
@@ -621,7 +621,7 @@ values are: `sum`, `mean` or `avg`, `max`, `concat` (concatenates along the firs
 vector of the first dimension).
 - **`loss`** (default `{type: softmax_cross_entropy}`): is a dictionary containing a loss `type`. `softmax_cross_entropy` is
 the only supported loss type for image output features. See [Loss](#loss) for details.
-- **`decoder`** (default: `{"type": "unet"}`): Decoder for the desired task. Options: `unet`. See [Decoder](#decoders) for details.
+- **`decoder`** (default: `{"type": "unet"}`): Decoder for the desired task. Options: `unet`, `segformer`, `fpn`. See [Decoder](#decoders) for details.
 
 ## Decoders
 
@@ -635,6 +635,62 @@ and combiner sections must be set to 0 as U-Net does not have any fully connecte
 U-Net Decoder takes the following optional parameters:
 
 {% set decoder = get_decoder_schema("image", "unet") %}
+{{ render_yaml(decoder, parent="decoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(decoder, exclude=["type"]), details=details) }}
+
+The decoder depth is configurable via `num_stages` (default `4`). Each stage doubles the
+spatial resolution during upsampling, so the combiner output height and width must be
+divisible by `2 ** num_stages`. Deeper stacks capture longer-range spatial context at the
+cost of more parameters.
+
+### SegFormer Decoder
+
+`segformer` implements the lightweight all-MLP decoder from
+[Xie et al., NeurIPS 2021](https://arxiv.org/abs/2105.15203). Instead of transposed
+convolutions it projects all encoder stages into a shared hidden size and fuses them with a
+single MLP — much cheaper than U-Net while remaining competitive on standard segmentation
+benchmarks when paired with a pretrained hierarchical encoder such as Swin or ConvNeXt V2.
+
+```yaml
+output_features:
+  - name: mask
+    type: image
+    decoder:
+      type: segformer
+      hidden_size: 256
+      dropout: 0.1
+      num_classes: 21
+```
+
+{% set decoder = get_decoder_schema("image", "segformer") %}
+{{ render_yaml(decoder, parent="decoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(decoder, exclude=["type"]), details=details) }}
+
+### FPN Decoder
+
+`fpn` implements the Feature Pyramid Network decoder from
+[Lin et al., CVPR 2017](https://arxiv.org/abs/1612.03144). It builds a top-down pyramid with
+lateral connections across multiple encoder stages, producing multi-scale features that are
+useful for dense prediction tasks and for segmenting objects at very different scales.
+
+```yaml
+output_features:
+  - name: mask
+    type: image
+    decoder:
+      type: fpn
+      num_channels: 256
+      num_levels: 4
+      num_classes: 80
+```
+
+{% set decoder = get_decoder_schema("image", "fpn") %}
 {{ render_yaml(decoder, parent="decoder") }}
 
 Parameters:

--- a/docs/configuration/features/loss_functions.md
+++ b/docs/configuration/features/loss_functions.md
@@ -1,0 +1,165 @@
+# Loss Functions
+
+This page documents the loss functions added in Ludwig 0.14. Each loss is registered for a
+specific set of feature types and is selected by setting `loss.type` on the output feature.
+
+For the complete loss catalog (including classic cross-entropy, MSE, MAE, and sequence
+losses), see the per-feature-type pages under **Features**.
+
+---
+
+## Focal loss
+
+Registered on: `binary`, `category`, `image`.
+
+[Focal loss](https://arxiv.org/abs/1708.02002) (Lin et al., ICCV 2017) down-weights easy
+examples and focuses training on hard, misclassified ones. It is the standard choice for
+imbalanced classification and dense detection tasks where a small number of positives are
+drowned out by the background class.
+
+```yaml
+output_features:
+  - name: label
+    type: category
+    loss:
+      type: focal_loss
+      alpha: 0.25     # class-balance factor
+      gamma: 2.0      # focusing parameter (0 → plain cross-entropy)
+```
+
+`gamma` controls how aggressively the loss suppresses easy examples (`(1 - p_t) ** gamma`).
+`alpha` rebalances the positive / negative contributions. Use `gamma ≈ 2.0` and
+`alpha ≈ 0.25` as a starting point for highly imbalanced problems.
+
+---
+
+## Dice loss
+
+Registered on: `image`.
+
+[Dice loss](https://arxiv.org/abs/1606.04797) (Milletari et al., 3DV 2016) directly
+optimizes the Sørensen–Dice coefficient and is the standard loss for binary and multi-class
+semantic segmentation — especially when foreground pixels are rare.
+
+```yaml
+output_features:
+  - name: mask
+    type: image
+    decoder:
+      type: unet
+    loss:
+      type: dice_loss
+      smooth: 1.0     # Laplace smoothing added to numerator and denominator
+```
+
+Dice loss is often combined with cross-entropy in practice. To approximate that, configure
+cross-entropy as the primary loss and add the Dice term as a secondary output feature with
+`weight < 1.0`, or switch between the two across training stages.
+
+---
+
+## Lovász-Softmax loss
+
+Registered on: `image`.
+
+[Lovász-Softmax](https://arxiv.org/abs/1705.08790) (Berman et al., CVPR 2018) is a convex
+surrogate for the mean intersection-over-union (mIoU) metric. Because it is trained
+directly on the quantity that is usually used to evaluate segmentation models, it often
+outperforms Dice and cross-entropy on the same task, particularly for classes with small
+spatial extent.
+
+```yaml
+output_features:
+  - name: mask
+    type: image
+    loss:
+      type: lovasz_softmax_loss
+```
+
+Lovász-Softmax has no tunable hyperparameters beyond the overall `weight`. It is more
+expensive than Dice because the loss is computed over sorted errors, but the extra cost is
+usually negligible compared to the encoder.
+
+---
+
+## PolyLoss
+
+Registered on: `category`.
+
+[PolyLoss](https://arxiv.org/abs/2204.12511) (Leng et al., ICLR 2022) reinterprets the
+cross-entropy loss as the leading term of a Taylor expansion and adds a single polynomial
+correction term `epsilon * (1 - p_t)`. The result typically produces small but consistent
+accuracy gains on classification benchmarks with no changes to the model or optimizer.
+
+```yaml
+output_features:
+  - name: class
+    type: category
+    loss:
+      type: poly_loss
+      epsilon: 1.0
+```
+
+PolyLoss-1 (`epsilon: 1.0`) is the starting point recommended by the paper. Sweep
+`epsilon ∈ [-1, 2]` if you need to tune it further.
+
+---
+
+## NT-Xent (contrastive)
+
+Registered on: `vector`.
+
+[NT-Xent](https://arxiv.org/abs/2002.05709) (normalized temperature-scaled cross-entropy,
+Chen et al., ICML 2020) is the contrastive objective used by SimCLR. Ludwig applies it on
+`vector` output features under the convention that consecutive rows in a batch
+`(2i, 2i + 1)` form a positive pair; all other cross-pair examples in the batch act as
+negatives.
+
+```yaml
+output_features:
+  - name: embedding
+    type: vector
+    loss:
+      type: nt_xent_loss
+      temperature: 0.07
+```
+
+Lower temperatures produce sharper contrasts and are preferred when the embedding space is
+high-dimensional (the SimCLR paper uses `0.1`). Feed the model two augmented views of each
+example so that every batch contains an even number of rows ordered as pairs.
+
+---
+
+## Entmax-1.5
+
+Registered on: `category`, `text`, `sequence`.
+
+`entmax_1.5_loss` was already implemented in earlier versions but is first registered for
+configuration use in 0.14. It trains the model under the sparse `entmax-1.5` projection
+([Peters et al., ACL 2019](https://arxiv.org/abs/1905.05702)), which sits between softmax
+and sparsemax and often yields more interpretable, sparse output distributions for
+classification tasks with many labels.
+
+```yaml
+output_features:
+  - name: tag
+    type: category
+    loss:
+      type: entmax_1.5_loss
+```
+
+No extra hyperparameters are required.
+
+---
+
+## Open-set recognition losses
+
+For open-set classification, see the dedicated
+[Open-Set Recognition](open_set_recognition.md) page, which documents the
+`entropic_open_set` and `objectosphere` losses registered on `binary` and `category`
+features.
+
+## Anomaly detection losses
+
+For anomaly detection, see the [Anomaly Features](anomaly_features.md) page, which
+documents the `deep_svdd`, `deep_sad`, and `drocc` losses registered on `anomaly` features.

--- a/docs/configuration/features/sequence_features.md
+++ b/docs/configuration/features/sequence_features.md
@@ -320,7 +320,7 @@ last vector of the sequence dimension).
 - **`loss`** (default `{type: softmax_cross_entropy, class_similarities_temperature: 0, class_weights: 1,
 confidence_penalty: 0, robust_lambda: 0}`): is a dictionary containing a loss `type`. The only available
 loss `type` for sequences is `softmax_cross_entropy`. See [Loss](#loss) for details.
-- **`decoder`** (default: `{"type": "generator"}`): Decoder for the desired task. Options: `generator`, `tagger`. See [Decoder](#decoders) for details.
+- **`decoder`** (default: `{"type": "generator"}`): Decoder for the desired task. Options: `generator`, `transformer_generator`, `tagger`. See [Decoder](#decoders) for details.
 
 Decoder type and decoder parameters can also be defined once and applied to all sequence output features using the [Type-Global Decoder](../defaults.md#type-global-decoder) section. Loss and loss related parameters can also be defined once in the same way.
 
@@ -368,6 +368,72 @@ during model building.
 Parameters:
 
 {{ render_fields(schema_class_to_fields(decoder, exclude=["type"])) }}
+
+#### Scheduled sampling
+
+By default the generator uses full teacher forcing: the decoder always receives the ground-truth
+previous token during training, which creates a mismatch with inference (where it must feed on
+its own predictions). Ludwig 0.14 exposes the scheduled-sampling curriculum from
+[Bengio et al., NeurIPS 2015](https://arxiv.org/abs/1506.03099), which gradually replaces
+teacher-forced inputs with sampled predictions as training progresses:
+
+```yaml
+decoder:
+  type: generator
+  cell_type: lstm
+  teacher_forcing_decay: linear      # none | linear | exponential
+  teacher_forcing_decay_rate: 0.01
+```
+
+`teacher_forcing_decay_rate` controls how quickly the teacher-forcing probability decays per
+step. Set `teacher_forcing_decay: none` (the default) to disable the curriculum.
+
+#### Beam search
+
+Both the RNN-based `generator` and the `transformer_generator` decoders support length-normalized
+beam search at inference:
+
+```yaml
+decoder:
+  type: generator
+  beam_width: 5
+  beam_length_penalty: 0.8
+```
+
+`beam_width: 1` is equivalent to greedy decoding. `beam_length_penalty > 1` favours shorter
+outputs; `< 1` favours longer ones (sequence score is divided by `length ** penalty`).
+
+### Transformer Generator
+
+The `transformer_generator` decoder replaces the autoregressive RNN with a stack of Transformer
+decoder blocks trained with teacher forcing. It tends to scale much better to long output
+sequences than the RNN decoder and benefits from mixed precision on GPU.
+
+```yaml
+output_features:
+  - name: output_seq
+    type: sequence
+    decoder:
+      type: transformer_generator
+      d_model: 256
+      num_layers: 2
+      num_heads: 8
+      ffn_size: 1024
+      dropout: 0.1
+      beam_width: 3
+      beam_length_penalty: 1.0
+```
+
+{% set decoder = get_decoder_schema("sequence", "transformer_generator") %}
+{{ render_yaml(decoder, parent="decoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(decoder, exclude=["type"])) }}
+
+!!! note
+    `d_model` must be divisible by `num_heads`. The feed-forward width `ffn_size` is usually
+    set to `4 * d_model`.
 
 ### Tagger
 

--- a/docs/configuration/large_language_model.md
+++ b/docs/configuration/large_language_model.md
@@ -215,6 +215,56 @@ output_features:
           value: "positive"
 ```
 
+Ludwig 0.14 expands `category_extractor` with two new match strategies and constrained
+decoding:
+
+| `match.<label>.type` | Use for | `value` |
+|----------------------|---------|---------|
+| `contains` | Simple substring matching | Literal string to look for in the generation |
+| `regex` | Flexible pattern matching | Python regex; the first match selects the label |
+| `json_schema` | LLMs asked to emit structured output | JSON value that must match the parsed JSON response |
+
+```yaml
+decoder:
+  type: category_extractor
+  match:
+    "positive":
+      type: regex
+      value: "(?i)\\bpositive\\b"
+    "negative":
+      type: regex
+      value: "(?i)\\bnegative\\b"
+```
+
+For `json_schema`, Ludwig parses the model's response as JSON and compares the resolved
+value against `value`. This is the recommended strategy when the prompt asks the LLM to
+return a JSON object.
+
+#### Constrained decoding
+
+Setting `constrain_to_vocabulary: true` on `category_extractor` installs a HuggingFace
+`LogitsProcessor` that masks out any token that cannot lead to a valid label prefix. The
+model is then guaranteed to generate one of the configured categories — useful for
+zero-shot classification tasks where parsing failures are unacceptable.
+
+```yaml
+output_features:
+  - name: label
+    type: category
+    decoder:
+      type: category_extractor
+      constrain_to_vocabulary: true
+      match:
+        "positive":
+          type: contains
+          value: "positive"
+        "negative":
+          type: contains
+          value: "negative"
+```
+
+Constrained decoding requires a HuggingFace tokenizer (the default for `llm` models).
+
 # Prompt
 
 One of the unique properties of large language models as compared to more conventional deep learning models is their ability to incorporate context inserted into the “prompt” to generate more specific and accurate responses.

--- a/docs/configuration/trainer.md
+++ b/docs/configuration/trainer.md
@@ -56,6 +56,121 @@ By default, the ECD trainer is used.
         clip_value: null
         ```
 
+## Optimizer guidance
+
+Ludwig 0.14 adds five optimizers on top of the existing PyTorch family. Quick picks:
+
+- **`radam`** — Rectified Adam (Liu et al., ICLR 2020). Drop-in replacement for `adam` that
+  removes the need for manual warmup by adaptively rectifying the variance of the adaptive
+  learning rate in the early steps.
+- **`adafactor`** — Adafactor (Shazeer & Stern, ICML 2018). Factorizes the second-moment matrix
+  to cut optimizer memory roughly in half, which makes it a common choice for fine-tuning
+  large transformers. When `relative_step: true` (the default) Adafactor manages its own
+  schedule — **do not combine it with a `learning_rate_scheduler`** and leave `learning_rate`
+  unset on the trainer.
+- **`schedule_free_adamw`** — Schedule-Free AdamW (Defazio et al., 2024). Matches cosine-decay
+  AdamW without needing an LR scheduler at all. The optimizer maintains two iterate states —
+  Ludwig handles the required `optimizer.train()` / `optimizer.eval()` calls automatically at
+  the train/eval boundaries.
+- **`muon`** — Muon (Jordan et al., 2024). Uses momentum plus Newton–Schulz orthogonalization
+  to produce stable, well-conditioned updates. Competitive with AdamW for pretraining and
+  typically uses a **much higher base learning rate than Adam** (default `0.02`).
+- **`soap`** — SOAP (Vyas et al., 2024). Shampoo-style preconditioner stacked on AdamW. Strong
+  empirical results on large-scale training; requires installing the optional `soap-pytorch`
+  package. Registered only when the dependency is available.
+
+!!! note
+    The legacy `ftrl` optimizer was removed in 0.14. Configs that set `optimizer.type: ftrl`
+    will fail validation — use `adagrad` or `sgd` with momentum as replacements.
+
+## Learning rate schedulers
+
+The `learning_rate_scheduler` section of the trainer controls how the learning rate evolves
+during training. Ludwig 0.14 adds four new schedule types on top of `linear`, `exponential`,
+and `cosine`:
+
+| `decay` | Best for | Key parameters |
+|---------|----------|----------------|
+| `one_cycle` | Fast supervised training, "superconvergence" | `max_lr`, `pct_start`, `div_factor`, `final_div_factor` |
+| `inverse_sqrt` | Transformer pretraining ("Noam" schedule) | `inverse_sqrt_warmup_steps` |
+| `polynomial` | Fine-tuning with a smooth ramp-down | `polynomial_power`, `polynomial_end_lr` |
+| `wsd` | Long continued pretraining with annealing | `wsd_warmup_fraction`, `wsd_stable_fraction`, `wsd_decay_fraction` |
+
+### OneCycleLR
+
+Implements Smith's 1-cycle policy: warm up from `initial_lr = max_lr / div_factor` to
+`max_lr` over `pct_start` of the total steps, then anneal down to
+`min_lr = initial_lr / final_div_factor`.
+
+```yaml
+trainer:
+  optimizer:
+    type: adamw
+  learning_rate_scheduler:
+    decay: one_cycle
+    max_lr: 0.001
+    pct_start: 0.3
+    div_factor: 25.0
+    final_div_factor: 10000.0
+```
+
+If `max_lr` is left unset it defaults to the trainer's `learning_rate`.
+
+### Inverse square root (Noam)
+
+After a linear warmup over `inverse_sqrt_warmup_steps`, the learning rate decays as
+`1 / sqrt(step)`. This is the schedule used in the original Transformer paper and is a good
+default for training language models from scratch.
+
+```yaml
+trainer:
+  learning_rate: 0.0005
+  learning_rate_scheduler:
+    decay: inverse_sqrt
+    inverse_sqrt_warmup_steps: 4000
+```
+
+### Polynomial decay
+
+Smoothly decays from the base learning rate to `polynomial_end_lr` over the full training
+run. `polynomial_power: 1.0` is linear decay; `2.0` is quadratic; values `< 1.0` decay
+faster early on.
+
+```yaml
+trainer:
+  learning_rate_scheduler:
+    decay: polynomial
+    polynomial_power: 1.0
+    polynomial_end_lr: 0.0
+```
+
+### Warmup-Stable-Decay (WSD)
+
+WSD splits the run into three phases — a short warmup, a long stable phase at the peak
+learning rate, and a short cooldown. Because the stable phase dominates, you can stop at
+any time and take a clean cooldown snapshot, which is useful for long pretraining runs
+where you want to branch continued training off of intermediate checkpoints.
+
+```yaml
+trainer:
+  learning_rate_scheduler:
+    decay: wsd
+    wsd_warmup_fraction: 0.1
+    wsd_stable_fraction: 0.8
+    wsd_decay_fraction: 0.1
+```
+
+The three fractions should sum to `1.0`.
+
+### Warmup and plateau parameters
+
+All schedules support the shared warmup and reduce-on-plateau knobs:
+
+- `warmup_fraction` / `warmup_evaluations` — linear warmup of the base learning rate.
+- `reduce_on_plateau`, `reduce_on_plateau_patience`, `reduce_on_plateau_rate` — cap the
+  number of on-plateau reductions and the reduction factor. Combine with `reduce_eval_metric`
+  and `reduce_eval_split` to pick which metric triggers the reduction.
+
 # Training length
 
 The length of the training process is configured by:

--- a/docs/user_guide/model_export.md
+++ b/docs/user_guide/model_export.md
@@ -39,6 +39,13 @@ CLI:
 ludwig export_model -m results/experiment_run/model -o exported/ -f torch_export
 ```
 
+!!! note
+    `export_model` accepts an optional `sample_input` dict mapping input-feature names to
+    tensors. When omitted (the default), Ludwig builds a dummy batch from the model's
+    training-set metadata — so the snippet above works as-is. Pass a real example only if
+    you need to trace against specific shapes or dtypes, for example when exporting models
+    that rely on dynamic axes.
+
 ### ONNX
 
 ONNX export uses the dynamo-based exporter (`torch.onnx.export(dynamo=True)`) for cross-platform deployment.
@@ -47,6 +54,9 @@ ONNX export uses the dynamo-based exporter (`torch.onnx.export(dynamo=True)`) fo
 model = LudwigModel.load("results/experiment_run/model")
 model.export_model("exported/", format="onnx")
 ```
+
+As with `torch_export`, `sample_input` is optional and is auto-generated from the training-set
+metadata when omitted.
 
 The exported ONNX model can be loaded with ONNX Runtime:
 

--- a/docs/user_guide/serving.md
+++ b/docs/user_guide/serving.md
@@ -63,9 +63,17 @@ curl http://0.0.0.0:8000/batch_predict -X POST \
 ```python
 from ludwig.serve_v2 import create_app
 
-app = create_app(model_path="path/to/model", timeout_seconds=300)
+app = create_app(
+    model_path="path/to/model",
+    allowed_origins=["*"],
+    prediction_timeout=300.0,
+)
 # Use with uvicorn, gunicorn, or any ASGI server
 ```
+
+The same timeout is exposed as the `--prediction_timeout` flag on `ludwig serve`. Requests
+that exceed the timeout return HTTP 504 and are emitted through the structured-logging
+middleware so they can be aggregated by downstream log collectors.
 
 ## LLM Serving with vLLM
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
       - Combiner: configuration/combiner.md
       - Trainer: configuration/trainer.md
       - Encoder Selection Guide: configuration/encoder_selection_guide.md
+      - Loss Functions: configuration/features/loss_functions.md
       - Hyperopt: configuration/hyperparameter_optimization.md
       - Backend: configuration/backend.md
   - 💡 Examples:


### PR DESCRIPTION
## Summary

Follow-up to the three docs PRs (#381 / #382 / #383) merged this week. Those covered
Phase 0-2 encoder modernization and Phase 3 export/serving. This PR fills in the
remaining 0.14 feature gaps surfaced by a sweep of the 34 commits between \`v0.13.0\`
and \`main\` on ludwig-ai/ludwig.

### Trainer

- **Optimizer guidance** for the five new 0.14 optimizers (\`radam\`, \`adafactor\`,
  \`schedule_free_adamw\`, \`muon\`, \`soap\`), including gotchas — Adafactor manages its
  own schedule, Schedule-Free needs train/eval mode toggles (Ludwig does this), Muon's
  default LR is much higher than Adam, SOAP needs the optional \`soap-pytorch\` package.
- Call out that \`ftrl\` was removed.
- New **Learning rate schedulers** section documenting \`one_cycle\`, \`inverse_sqrt\`,
  \`polynomial\`, and \`wsd\` (Warmup-Stable-Decay).

### Decoders

- **Sequence**: new \`transformer_generator\` decoder, scheduled sampling via
  \`teacher_forcing_decay\`, and \`beam_width\` / \`beam_length_penalty\` beam search.
- **Image**: configurable U-Net \`num_stages\`, plus new \`segformer\` and \`fpn\`
  segmentation decoders.
- **Category**: new \`mlp_classifier\` decoder, \`calibration: temperature_scaling\`, and
  \`mc_dropout_samples\` for uncertainty estimation.
- **LLM**: \`category_extractor\` now supports \`regex\` and \`json_schema\` match
  strategies plus \`constrain_to_vocabulary\` for constrained decoding.

### Losses

New page \`configuration/features/loss_functions.md\` covering the 0.14 loss additions:

- \`focal_loss\` (binary / category / image)
- \`dice_loss\` and \`lovasz_softmax_loss\` (image segmentation)
- \`poly_loss\` (category)
- \`nt_xent_loss\` (vector, SimCLR-style contrastive)
- \`entmax_1.5_loss\` (newly registered on category / text / sequence)

Linked from the Configuration nav. Cross-references the existing
\`open_set_recognition.md\` and \`anomaly_features.md\` pages for losses that already
have dedicated documentation.

### Serving

- Fix the Python API example — \`create_app\` accepts \`prediction_timeout\`, not the
  non-existent \`timeout_seconds\` kwarg.
- Mention the matching \`--prediction_timeout\` CLI flag and structured-logging
  behaviour for HTTP 504 responses.

### Model export

- Clarify that \`sample_input\` is optional for both \`torch_export\` and \`onnx\`
  formats and is auto-generated from training-set metadata when omitted, so the
  minimal \`model.export_model("exported/", format="torch_export")\` example actually
  works as written.

## Test plan

- [ ] \`mkdocs build\` locally and spot-check each new section renders without macro errors
- [ ] Visually confirm auto-rendered schemas for \`transformer_generator\`, \`mlp_classifier\`,
      \`segformer\`, and \`fpn\` decoders pull real fields from the Ludwig repo
- [ ] Verify the new \`Loss Functions\` page appears in the Configuration nav