### PR TITLE
feat: SEO and AI discoverability improvements

### DIFF
--- a/custom/main.html
+++ b/custom/main.html
@@ -65,4 +65,59 @@
   <meta name="twitter:title" content="{{ og_title }}">
   <meta name="twitter:description" content="{{ og_desc }}">
   <meta name="twitter:image" content="https://ludwig.ai/latest/images/og-image.jpg">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Ludwig AI",
+    "url": "https://ludwig.ai",
+    "logo": "https://ludwig.ai/latest/images/ludwig_logo.svg",
+    "sameAs": [
+      "https://github.com/ludwig-ai/ludwig",
+      "https://twitter.com/ludwig_ai"
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Ludwig",
+    "url": "https://ludwig.ai/",
+    "description": "Open-source declarative deep learning framework. Train, fine-tune, and deploy models using a simple YAML config file.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://ludwig.ai/latest/?q={search_term_string}"
+      },
+      "query-input": "required name=search_term_string"
+    }
+  }
+  </script>
+  {%- if page and page.title %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Ludwig",
+        "item": "https://ludwig.ai/latest/"
+      }
+      {%- if page.title != "Ludwig" %},
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "{{ page.title }}",
+        "item": "https://ludwig.ai/latest/{{ page.url }}"
+      }
+      {%- endif %}
+    ]
+  }
+  </script>
+  {%- endif %}
 {% endblock %}

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,3 +1,7 @@
+---
+description: Install Ludwig via pip, Docker, or from source. Supports optional dependency groups for LLMs, distributed training on Ray, audio, and more.
+---
+
 # Use pip
 
 For users familiar with Python, we recommend installing with [`pip`](https://pip.pypa.io/en/stable/) within an isolated

--- a/docs/getting_started/llm_finetuning.md
+++ b/docs/getting_started/llm_finetuning.md
@@ -1,3 +1,7 @@
+---
+description: Quickstart guide to fine-tuning Llama 2 with QLoRA in Ludwig. Run 4-bit LLM fine-tuning locally with a single YAML config — no custom PyTorch code needed.
+---
+
 # Llama2-7b Fine-Tuning 4bit (QLoRA)
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1c3AO8l_H6V_x37RwQ8V7M6A-RmcBf2tG?usp=sharing)

--- a/docs/getting_started/train.md
+++ b/docs/getting_started/train.md
@@ -1,3 +1,7 @@
+---
+description: Step-by-step guide to training your first model with Ludwig. Define input/output features in a YAML config and run ludwig train — no custom code needed.
+---
+
 To train a model with Ludwig, we first need to create a [Ludwig configuration](./../configuration/index.md). The config specifies input features, output features, preprocessing, model architecture, training loop, hyperparameter search, and backend infrastructure -- everything that's needed to build, train, and evaluate a model.
 
 At a minimum, the config must specify the model's input and output features.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+description: Ludwig is an open-source declarative deep learning framework. Train, fine-tune, and deploy models for text, image, tabular, audio, and LLMs using a simple YAML config file — no custom code required.
+---
+
 ![Ludwig logo](images/ludwig_hero_transparent.png#only-light)
 ![Ludwig logo](images/ludwig_hero_transparent_dark.png#only-dark)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,66 @@
+# Ludwig
+
+> Ludwig is an open-source declarative deep learning framework that lets you train, fine-tune, and deploy models with a YAML config file — no custom PyTorch or TensorFlow code required. Supports LLM fine-tuning (LoRA/QLoRA), GRPO alignment, multimodal training, distributed training on Ray, and 30+ data types out of the box.
+
+Ludwig is maintained by the Linux Foundation AI & Data and has 10,000+ GitHub stars. It is designed for both researchers who want rapid experimentation and engineers who need production-grade ML pipelines. The same YAML config drives local training, Ray-distributed multi-GPU runs, and deployment via REST API.
+
+## Getting Started
+- [Introduction](https://ludwig.ai/latest/) – What Ludwig is and why to use it
+- [Installation](https://ludwig.ai/latest/getting_started/installation/) – pip install, Docker, and optional dependency groups
+- [Training your first model](https://ludwig.ai/latest/getting_started/train/) – End-to-end example: config → train → predict
+- [Dataset preparation](https://ludwig.ai/latest/getting_started/prepare_data/) – CSV, Parquet, HuggingFace datasets, Ludwig dataset zoo
+- [LLM fine-tuning quickstart](https://ludwig.ai/latest/getting_started/llm_finetuning/) – QLoRA on Llama-3 in one config file
+- [Serving a trained model](https://ludwig.ai/latest/getting_started/serve/) – REST API with `ludwig serve`
+- [Distributed training on Ray](https://ludwig.ai/latest/getting_started/ray/) – Scale to multi-GPU / multi-node with one config change
+
+## User Guide
+- [What is Ludwig?](https://ludwig.ai/latest/user_guide/what_is_ludwig/) – Core concepts: declarative ML, config-driven training, multi-task learning
+- [How Ludwig works](https://ludwig.ai/latest/user_guide/how_ludwig_works/) – Architecture: encoders, combiners, decoders, trainers
+- [Large Language Models](https://ludwig.ai/latest/user_guide/llms/) – LLM fine-tuning, in-context learning, structured output
+- [LLM fine-tuning in depth](https://ludwig.ai/latest/user_guide/llms/finetuning/) – SFT, LoRA, QLoRA, adapter merging, HF Hub upload
+- [In-context learning](https://ludwig.ai/latest/user_guide/llms/in_context_learning/) – Zero-shot and few-shot inference without training
+- [Distributed training](https://ludwig.ai/latest/user_guide/distributed_training/) – DDP, FSDP, DeepSpeed on Ray
+- [AutoML](https://ludwig.ai/latest/user_guide/automl/) – Automatic architecture search and hyperparameter optimization
+- [Hyperparameter optimization](https://ludwig.ai/latest/user_guide/hyperopt/) – Grid search, random, Bayesian with Ray Tune
+- [GPUs](https://ludwig.ai/latest/user_guide/gpus/) – Single-GPU and multi-GPU setup
+- [Model export](https://ludwig.ai/latest/user_guide/model_export/) – TorchScript, ONNX, Triton, HuggingFace Hub
+- [Third-party integrations](https://ludwig.ai/latest/user_guide/integrations/) – MLflow, Weights & Biases, Comet, DVC
+
+## Configuration Reference
+- [Configuration overview](https://ludwig.ai/latest/configuration/) – Full YAML schema reference
+- [Model types](https://ludwig.ai/latest/configuration/model_type/) – ECD (encoder-combiner-decoder) vs. LLM
+- [Large Language Model config](https://ludwig.ai/latest/configuration/large_language_model/) – base_model, quantization, adapter, PEFT
+- [Encoder selection guide](https://ludwig.ai/latest/configuration/encoder_selection_guide/) – Which encoder to use for text, image, audio, tabular
+- [Trainer config](https://ludwig.ai/latest/configuration/trainer/) – Epochs, learning rate, scheduler, optimizer
+- [Backend config](https://ludwig.ai/latest/configuration/backend/) – Ray, local, Horovod settings
+- [Preprocessing config](https://ludwig.ai/latest/configuration/preprocessing/) – Per-feature preprocessing options
+- [Combiner config](https://ludwig.ai/latest/configuration/combiner/) – concat, tabnet, transformer, project_aggregate
+
+## Input Feature Types
+- [Text features](https://ludwig.ai/latest/configuration/features/text_features/) – Encoders: BERT, ModernBERT, RoBERTa, DeBERTa, GPT-2, auto_transformer
+- [Image features](https://ludwig.ai/latest/configuration/features/image_features/) – Encoders: DINOv2, ViT, EfficientNet, ResNet, stacked_cnn
+- [Category features](https://ludwig.ai/latest/configuration/features/category_features/) – Embeddings, one-hot, sparse
+- [Number features](https://ludwig.ai/latest/configuration/features/number_features/) – Normalization, missing value handling
+- [Audio features](https://ludwig.ai/latest/configuration/features/audio_features/) – Encoders: STFT, mel, wav2vec2, encodec
+- [Time series features](https://ludwig.ai/latest/configuration/features/time_series_features/) – Transformer encoder, window size, forecasting
+- [Supported data types](https://ludwig.ai/latest/configuration/features/supported_data_types/) – All 14 supported feature types
+
+## Examples
+- [Text classification](https://ludwig.ai/latest/examples/text_classification/) – Sentiment analysis with ModernBERT
+- [LLM fine-tuning for classification](https://ludwig.ai/latest/examples/llms/llm_classification/) – Use Llama-3 for tabular classification
+- [LLM instruction tuning](https://ludwig.ai/latest/examples/llms/llm_finetuning/) – Alpaca-style SFT with LoRA
+- [Image classification](https://ludwig.ai/latest/examples/mnist/) – MNIST with DINOv2 / ResNet
+- [Multimodal classification](https://ludwig.ai/latest/examples/multimodal_classification/) – Image + text + tabular in one config
+- [Tabular data classification](https://ludwig.ai/latest/examples/adult_census_income/) – Census income prediction
+- [Hyperparameter optimization](https://ludwig.ai/latest/examples/hyperopt/) – Ray Tune integration
+- [Named entity recognition](https://ludwig.ai/latest/examples/ner_tagging/) – Sequence labeling
+- [Visual question answering](https://ludwig.ai/latest/examples/visual_qa/) – Multimodal VQA
+
+## API Reference
+- [LudwigModel Python API](https://ludwig.ai/latest/user_guide/api/LudwigModel/) – train(), predict(), evaluate(), save(), load()
+- [Command line interface](https://ludwig.ai/latest/user_guide/command_line_interface/) – ludwig train, predict, evaluate, serve, hyperopt, export
+
+## Community & Contributing
+- [FAQ](https://ludwig.ai/latest/faq/) – Common questions about Ludwig
+- [Contributing guide](https://ludwig.ai/latest/developer_guide/contributing/) – How to contribute code, docs, and examples
+- [GitHub](https://github.com/ludwig-ai/ludwig) – Source code, issues, discussions

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -2,3 +2,31 @@ User-agent: *
 Allow: /
 Sitemap: https://ludwig.ai/sitemap.xml
 Host: https://ludwig.ai/
+
+# AI training and retrieval crawlers — explicitly allowed
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: GoogleOther
+Allow: /
+
+User-agent: CCBot
+Allow: /

--- a/docs/user_guide/llms/finetuning.md
+++ b/docs/user_guide/llms/finetuning.md
@@ -1,3 +1,7 @@
+---
+description: Fine-tune LLMs with Ludwig using LoRA, QLoRA, or full fine-tuning. Covers SFT, PEFT adapters, quantization, and pushing trained adapters to Hugging Face Hub.
+---
+
 Fine-tuning is the process of modifying the weights of a Large Language Model to help it
 perform better on a specific task or set of tasks.
 

--- a/docs/user_guide/what_is_ludwig.md
+++ b/docs/user_guide/what_is_ludwig.md
@@ -1,3 +1,7 @@
+---
+description: Learn what Ludwig is — a declarative ML framework that lets you train, fine-tune, and deploy deep learning models with a YAML config file. Covers core concepts, supported data types, and the encoder-combiner-decoder architecture.
+---
+
 # Introduction
 
 Ludwig is an open-source, [declarative machine learning framework](#why-declarative-machine-learning-systems)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,6 @@ These catch breakage when Ludwig's schema API changes (e.g. get_class_schema
 removed in pydantic-v2 migration) before it reaches the CI docs build.
 """
 
-import sys
 import pytest
 
 # Ludwig's schema metaclass is incompatible with pydantic 2.13 on Python 3.14+.
@@ -89,7 +88,8 @@ def test_schema_class_long_description():
 
 def test_no_get_class_schema_calls():
     """Ensure main.py never calls get_class_schema (removed in pydantic v2)."""
-    import ast, pathlib
+    import ast
+    import pathlib
 
     src = pathlib.Path(__file__).parent.parent / "main.py"
     tree = ast.parse(src.read_text())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,9 +39,14 @@ def _make_env():
 @requires_ludwig
 def test_define_env_registers_macros():
     from main import define_env
+
     env = _make_env()
     define_env(env)
-    for name in ("schema_class_to_yaml", "schema_class_to_fields", "schema_class_long_description"):
+    for name in (
+        "schema_class_to_yaml",
+        "schema_class_to_fields",
+        "schema_class_long_description",
+    ):
         assert name in env._macros, f"macro {name!r} not registered"
 
 
@@ -49,6 +54,7 @@ def test_define_env_registers_macros():
 def test_schema_class_to_yaml():
     from main import define_env
     from ludwig.schema.preprocessing import PreprocessingConfig
+
     env = _make_env()
     define_env(env)
     result = env._macros["schema_class_to_yaml"](PreprocessingConfig)
@@ -60,6 +66,7 @@ def test_schema_class_to_yaml():
 def test_schema_class_to_fields():
     from main import define_env
     from ludwig.schema.preprocessing import PreprocessingConfig
+
     env = _make_env()
     define_env(env)
     result = env._macros["schema_class_to_fields"](PreprocessingConfig)
@@ -71,6 +78,7 @@ def test_schema_class_to_fields():
 def test_schema_class_long_description():
     from main import define_env
     from ludwig.schema.combiners.utils import get_combiner_registry
+
     env = _make_env()
     define_env(env)
     # Use a combiner that has a 'type' field
@@ -82,8 +90,11 @@ def test_schema_class_long_description():
 def test_no_get_class_schema_calls():
     """Ensure main.py never calls get_class_schema (removed in pydantic v2)."""
     import ast, pathlib
+
     src = pathlib.Path(__file__).parent.parent / "main.py"
     tree = ast.parse(src.read_text())
     for node in ast.walk(tree):
         if isinstance(node, ast.Attribute) and node.attr == "get_class_schema":
-            pytest.fail(f"main.py calls get_class_schema at line {node.lineno} — use model_fields instead")
+            pytest.fail(
+                f"main.py calls get_class_schema at line {node.lineno} — use model_fields instead"
+            )


### PR DESCRIPTION
## Summary

- **`docs/llms.txt`** — new file following the [llms.txt standard](https://llmstxt.org/) (Jeremy Howard / answer.ai). A structured Markdown index of all key Ludwig pages with descriptions, served at `https://ludwig.ai/llms.txt`. LLM crawlers consume this instead of scraping HTML, cutting token overhead 4–5x.
- **`docs/robots.txt`** — explicitly allows GPTBot, ClaudeBot, anthropic-ai, PerplexityBot, Meta-ExternalAgent, Applebot, cohere-ai, GoogleOther, CCBot. Explicit allow > relying on the wildcard default for AI crawlers.
- **`custom/main.html`** — adds three JSON-LD schemas rendered on every page:
  - `Organization` (name, URL, logo, GitHub/Twitter sameAs links)
  - `WebSite` (with `SearchAction` for Google Sitelinks Searchbox)
  - `BreadcrumbList` (injected per-page when `page.title` is set)
- **Frontmatter `description`** added to six high-traffic pages (`index.md`, `installation.md`, `train.md`, `llm_finetuning.md`, `what_is_ludwig.md`, `llms/finetuning.md`). The existing OG/Twitter meta tags in `main.html` already read `page.meta.description`, so this automatically improves social previews and search snippets for these pages.

## Test plan

- [ ] Build docs locally (`mkdocs serve`) and inspect `<head>` for JSON-LD on home and a sub-page
- [ ] Confirm `https://ludwig.ai/llms.txt` resolves after deploy
- [ ] Validate JSON-LD with Google's Rich Results Test tool
- [ ] Check `robots.txt` at `https://ludwig.ai/robots.txt` after deploy