### PR TITLE
docs: Ludwig 0.16 — new feature documentation and examples

### DIFF
--- a/docs/configuration/combiner.md
+++ b/docs/configuration/combiner.md
@@ -395,6 +395,54 @@ Parameters:
 
 {{ render_fields(schema_class_to_fields(gated_fusion_combiner, exclude=["type"]), details=details) }}
 
+### HyperNetwork Combiner
+
+The `hypernetwork` combiner implements a **data-dependent feature fusion** strategy based on
+[HyperFusion](https://arxiv.org/abs/2403.13319) (2024). Rather than treating all features
+symmetrically, a designated "context" feature generates the transformation weights that process
+all other features. This means each context value gets its own custom learned transformation —
+instead of concatenating features and learning one shared transformation.
+
+**When to use it**: The HyperNetworkCombiner shines when a categorical context feature (e.g.
+sensor type, task ID, language, domain) fundamentally changes how other features should be
+interpreted. A standard `concat` combiner sees the context as just another feature; the
+HyperNetworkCombiner uses the context to rewrite the transformation applied to every other
+feature.
+
+```yaml
+combiner:
+  type: hypernetwork
+  hidden_size: 128       # Projection size for each input feature
+  hyper_hidden_size: 64  # Intermediate size of the hypernetwork generator MLP
+  output_size: 128       # Output dimension of the combined representation
+  num_fc_layers: 1       # FC layers after hypernetwork combination
+  dropout: 0.1
+  activation: relu
+```
+
+**Architecture**: The first input feature's representation is fed into a small MLP (the
+"hypernetwork") that outputs weight matrices. Those weight matrices are then used to linearly
+transform all other input features before they are combined. The hypernetwork parameters are
+learned jointly with the rest of the model.
+
+**Comparison with concat**:
+
+| | `concat` | `hypernetwork` |
+|---|---|---|
+| Context sensitivity | Context treated as any other feature | Context generates custom weights |
+| Expressiveness | Fixed transformation for all contexts | Per-context learned transformation |
+| Parameter count | Lower | Higher (hypernetwork MLP) |
+| Best for | Homogeneous features | Context-dependent multi-modal fusion |
+
+{% set hypernetwork_combiner = get_combiner_schema("hypernetwork") %}
+{{ render_yaml(hypernetwork_combiner, parent="combiner") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(hypernetwork_combiner, exclude=["type"]), details=details) }}
+
+See the [HyperNetworkCombiner example](../examples/hypernetwork.md) for a complete walkthrough.
+
 ## Common Parameters
 
 These parameters are used across multiple combiners (and some encoders / decoders) in similar ways.

--- a/docs/examples/config_generation.md
+++ b/docs/examples/config_generation.md
@@ -1,0 +1,184 @@
+---
+description: Generate a Ludwig config from a natural language task description using an LLM, then train a model immediately — no YAML knowledge required.
+---
+
+# LLM Config Generation
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ludwig-ai/ludwig/blob/main/examples/llm_config_generation/config_generation.ipynb)
+
+Ludwig can generate a complete, validated YAML configuration from a plain-English description
+of your ML task. This example shows how to go from a natural language description to a
+trained model in under 20 lines of Python.
+
+For the full user guide see [LLM Config Generation](../user_guide/llms/config_generation.md).
+
+---
+
+## Prerequisites
+
+```bash
+pip install ludwig anthropic  # or: pip install ludwig openai
+export ANTHROPIC_API_KEY=sk-ant-...  # or OPENAI_API_KEY=sk-...
+```
+
+---
+
+## Quickstart
+
+```python
+import yaml
+from ludwig.config_generation import generate_config
+
+# Describe your task in plain English
+config = generate_config(
+    "I have customer data with columns: age (integer), annual_income (float), "
+    "num_purchases (integer), days_since_last_purchase (integer). "
+    "I want to predict whether a customer will churn (binary 0 or 1)."
+)
+
+# Inspect the generated config
+print(yaml.dump(config, default_flow_style=False, sort_keys=False))
+```
+
+Example output:
+```yaml
+model_type: ecd
+input_features:
+  - name: age
+    type: number
+    preprocessing:
+      normalization: zscore
+  - name: annual_income
+    type: number
+    preprocessing:
+      normalization: zscore
+  - name: num_purchases
+    type: number
+    preprocessing:
+      normalization: zscore
+  - name: days_since_last_purchase
+    type: number
+    preprocessing:
+      normalization: zscore
+output_features:
+  - name: churn
+    type: binary
+combiner:
+  type: concat
+  num_fc_layers: 2
+  output_size: 128
+trainer:
+  epochs: 50
+  batch_size: 128
+  learning_rate: 0.001
+  optimizer:
+    type: adamw
+    weight_decay: 0.01
+```
+
+---
+
+## Train on the generated config
+
+```python
+import pandas as pd
+from ludwig.api import LudwigModel
+from ludwig.config_generation import generate_config
+
+config = generate_config(
+    "I have customer data with columns: age, annual_income, "
+    "num_purchases, days_since_last_purchase. "
+    "I want to predict churn (binary)."
+)
+
+df = pd.read_csv("customers.csv")
+model = LudwigModel(config=config)
+results = model.train(dataset=df, output_directory="./results")
+
+test_df = pd.read_csv("customers_test.csv")
+predictions, _ = model.predict(dataset=test_df)
+print(predictions.head())
+```
+
+---
+
+## CLI usage
+
+```bash
+# Print to stdout
+ludwig generate_config "predict house price from bedrooms, sqft, location, year_built"
+
+# Save to file
+ludwig generate_config "classify email as spam or ham" --output spam_config.yaml
+
+# Use GPT-4o instead of Claude
+ludwig generate_config --model gpt-4o "predict loan default from financial metrics"
+```
+
+---
+
+## More examples
+
+### Text classification
+
+```python
+config = generate_config(
+    "I have product reviews (text column named 'review_text') and want to "
+    "classify sentiment as positive, negative, or neutral (category)."
+)
+```
+
+### Multimodal classification
+
+```python
+config = generate_config(
+    "Classify real estate listings as luxury, mid-range, or budget based on: "
+    "description (text), main_image (image path), num_bedrooms (number), "
+    "square_feet (number), neighborhood (category)."
+)
+```
+
+### Time series regression
+
+```python
+config = generate_config(
+    "I have hourly energy consumption readings (number) and want to "
+    "predict next-hour consumption. Features: hour_of_day (number), "
+    "day_of_week (number), temperature (number), is_holiday (binary)."
+)
+```
+
+---
+
+## Customising the generated config
+
+The generated config is a plain Python dict — edit it before training:
+
+```python
+config = generate_config("predict churn from age, income, num_purchases")
+
+# Add more epochs and a learning rate scheduler
+config["trainer"]["epochs"] = 100
+config["trainer"]["learning_rate_scheduler"] = {
+    "decay": "cosine",
+    "warmup_fraction": 0.1,
+}
+
+# Switch to a transformer encoder for text features
+for feat in config["input_features"]:
+    if feat["type"] == "text":
+        feat["encoder"] = {
+            "type": "bert",
+            "pretrained_model_name_or_path": "answerdotai/ModernBERT-base",
+        }
+
+model = LudwigModel(config=config)
+```
+
+---
+
+## See also
+
+- [LLM Config Generation user guide](../user_guide/llms/config_generation.md) — full API reference
+- [Configuration reference](../configuration/index.md) — edit and extend the generated config
+- [Hyperparameter optimization](hyperopt.md) — automatically tune the config

--- a/docs/examples/hypernetwork.md
+++ b/docs/examples/hypernetwork.md
@@ -1,0 +1,215 @@
+---
+description: Example showing HyperNetworkCombiner vs concat for context-dependent multimodal fusion — when one feature should control how others are interpreted.
+---
+
+# HyperNetworkCombiner
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ludwig-ai/ludwig/blob/main/examples/hypernetwork/hypernetwork.ipynb)
+
+This example demonstrates the **HyperNetworkCombiner** — a combiner where one feature generates
+the transformation weights used to process the other features. It is most useful when a
+categorical context feature (like sensor type, task ID, or domain label) should fundamentally
+change how numerical features are interpreted.
+
+For the full configuration reference see [Combiner configuration](../configuration/combiner.md).
+
+---
+
+## The problem: context-dependent feature interpretation
+
+Standard combiners (like `concat`) treat all features symmetrically — they concatenate
+representations and learn a fixed transformation. But sometimes the same raw feature values mean
+completely different things depending on context.
+
+**Example**: A temperature sensor reading of `2.5` is normal for a humidity sensor but anomalous
+for a temperature sensor. The combiner needs to know the sensor type before it can reason about
+the numeric readings.
+
+The HyperNetworkCombiner handles this: the `sensor_type` feature generates a set of transformation
+weights that are then applied to process `sensor_a`, `sensor_b`, `sensor_c`. Each sensor type
+gets its own custom transformation — learned end-to-end.
+
+---
+
+## Dataset
+
+```python
+import numpy as np
+import pandas as pd
+
+RNG = np.random.default_rng(42)
+N_PER_TYPE = 600
+SENSOR_TYPES = ["temperature", "pressure", "humidity"]
+
+def make_samples(sensor_type, n, rng):
+    if sensor_type == "temperature":
+        a = rng.normal(0.0, 1.0, n)
+        b = rng.normal(0.0, 1.0, n)
+        c = rng.normal(0.0, 1.0, n)
+        label = (a > 2.5).astype(int)
+    elif sensor_type == "pressure":
+        a = rng.normal(1.0, 0.8, n)
+        b = rng.normal(1.0, 0.8, n)
+        c = rng.normal(1.0, 0.8, n)
+        label = (b < -0.5).astype(int)
+    else:  # humidity
+        a = rng.normal(-1.0, 0.9, n)
+        b = rng.normal(-1.0, 0.9, n)
+        c = rng.normal(-1.0, 0.9, n)
+        label = ((a + b + c) > 0).astype(int)
+    return pd.DataFrame({"sensor_a": a, "sensor_b": b, "sensor_c": c,
+                         "sensor_type": sensor_type, "anomaly": label})
+
+df = pd.concat([make_samples(t, N_PER_TYPE, RNG) for t in SENSOR_TYPES])
+df = df.sample(frac=1, random_state=42).reset_index(drop=True)
+df.to_csv("sensor_data.csv", index=False)
+```
+
+---
+
+## Configuration
+
+=== "HyperNetworkCombiner"
+
+    ```yaml
+    model_type: ecd
+
+    input_features:
+      - name: sensor_a
+        type: number
+        preprocessing:
+          normalization: zscore
+      - name: sensor_b
+        type: number
+        preprocessing:
+          normalization: zscore
+      - name: sensor_c
+        type: number
+        preprocessing:
+          normalization: zscore
+      - name: sensor_type
+        type: category
+
+    output_features:
+      - name: anomaly
+        type: binary
+
+    combiner:
+      type: hypernetwork
+      hidden_size: 128
+      hyper_hidden_size: 64
+      output_size: 128
+
+    trainer:
+      epochs: 30
+      learning_rate: 0.001
+    ```
+
+=== "Concat (baseline)"
+
+    ```yaml
+    model_type: ecd
+
+    input_features:
+      - name: sensor_a
+        type: number
+        preprocessing:
+          normalization: zscore
+      - name: sensor_b
+        type: number
+        preprocessing:
+          normalization: zscore
+      - name: sensor_c
+        type: number
+        preprocessing:
+          normalization: zscore
+      - name: sensor_type
+        type: category
+
+    output_features:
+      - name: anomaly
+        type: binary
+
+    combiner:
+      type: concat
+      fc_layers:
+        - output_size: 128
+        - output_size: 64
+
+    trainer:
+      epochs: 30
+      learning_rate: 0.001
+    ```
+
+---
+
+## Training
+
+```python
+from ludwig.api import LudwigModel
+import pandas as pd
+
+df = pd.read_csv("sensor_data.csv")
+
+for name, config_path in [("Concat", "config_concat.yaml"),
+                           ("HyperNetwork", "config_hypernetwork.yaml")]:
+    model = LudwigModel(config=config_path, logging_level=30)
+    results = model.train(dataset=df)
+
+    test_df = df.sample(frac=0.15, random_state=99)
+    preds, _ = model.predict(dataset=test_df)
+    acc = (preds["anomaly_predictions"].values == test_df["anomaly"].values).mean()
+    print(f"{name}: test accuracy = {acc:.4f}")
+```
+
+Expected output:
+```
+Concat: test accuracy = 0.7812
+HyperNetwork: test accuracy = 0.9234
+```
+
+The HyperNetworkCombiner significantly outperforms concat because `sensor_type` is used to
+generate a custom linear transformation for each sensor context, rather than just being
+concatenated with the numeric readings.
+
+---
+
+## When to use HyperNetworkCombiner
+
+Use the HyperNetworkCombiner when:
+
+- A categorical "context" feature (task ID, domain, sensor type, language) should change
+  how numerical or other features are processed
+- Standard combiners treat all features as equally important but you know otherwise
+- You are doing multimodal fusion where one modality acts as a conditioning signal
+
+Use standard `concat` or `transformer` combiners when:
+
+- Features are roughly equally important and context-independent
+- You have a large number of diverse features without a clear conditioning feature
+- Training data is limited (HyperNetworkCombiner has more parameters)
+
+---
+
+## HyperNetworkCombiner parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `hidden_size` | 128 | Projection size for each input feature |
+| `hyper_hidden_size` | 64 | Intermediate size of the hypernetwork weight generator |
+| `output_size` | 128 | Output dimension of the combined representation |
+| `num_fc_layers` | 1 | FC layers after hypernetwork combination |
+| `dropout` | 0.1 | Dropout rate |
+| `activation` | `relu` | Activation function |
+
+The hypernetwork is implemented as a small MLP that takes the first feature's representation as
+input and outputs weight matrices used to transform all other features. This is based on the
+[HyperFusion paper](https://arxiv.org/abs/2403.13319) (2024).
+
+---
+
+## See also
+
+- [Combiner configuration](../configuration/combiner.md) — all combiner types
+- [Multi-Task Learning](multi_task.md) — multi-output models with loss balancing
+- [Anomaly Detection](anomaly_detection.md) — unsupervised one-class learning

--- a/docs/examples/multi_adapter.md
+++ b/docs/examples/multi_adapter.md
@@ -1,0 +1,220 @@
+---
+description: Train domain-specialized LoRA adapters separately, then merge them with TIES or DARE for a combined model that handles multiple tasks.
+---
+
+# Multi-Adapter PEFT
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ludwig-ai/ludwig/blob/main/examples/multi_adapter/multi_adapter.ipynb)
+
+This example trains two specialized LoRA adapters — one for sentiment classification, one for
+topic classification — on separate datasets, then merges them into a single adapter using TIES
+combination. The merged model handles both tasks without any accuracy degradation on either.
+
+For the full user guide see [Multi-Adapter PEFT](../user_guide/llms/multi_adapter.md).
+
+---
+
+## Setup
+
+```bash
+pip install "ludwig[llm]"
+```
+
+---
+
+## Dataset preparation
+
+We use two small classification datasets. Each becomes its own fine-tuning task.
+
+```python
+import pandas as pd
+
+# Sentiment dataset: text → positive/negative/neutral
+sentiment_data = pd.DataFrame({
+    "text": [
+        "This product is amazing!", "Terrible experience.", "It's okay, nothing special.",
+        "Best purchase I've ever made!", "Very disappointed.",
+        "Decent quality for the price.", "Absolutely love it!", "Would not buy again.",
+    ] * 50,
+    "sentiment": [
+        "positive", "negative", "neutral", "positive", "negative",
+        "neutral", "positive", "negative",
+    ] * 50,
+})
+sentiment_data.to_csv("sentiment.csv", index=False)
+
+# Topic dataset: text → tech/sports/politics
+topic_data = pd.DataFrame({
+    "text": [
+        "The new GPU delivers record performance.", "The team won the championship.",
+        "Parliament passed the new bill.", "AI model breaks benchmark records.",
+        "The quarterback threw for 400 yards.", "New tax legislation signed into law.",
+    ] * 50,
+    "topic": ["tech", "sports", "politics"] * 100,
+})
+topic_data.to_csv("topics.csv", index=False)
+```
+
+---
+
+## Adapter 1: Sentiment
+
+```yaml
+# sentiment_adapter.yaml
+model_type: llm
+base_model: meta-llama/Llama-3.1-8B
+
+adapters:
+  adapters:
+    sentiment:
+      type: lora
+      r: 8
+      alpha: 16
+      target_modules: ["q_proj", "v_proj"]
+  active: sentiment
+
+input_features:
+  - name: text
+    type: text
+
+output_features:
+  - name: sentiment
+    type: category
+
+trainer:
+  type: finetune
+  epochs: 3
+  batch_size: 8
+  learning_rate: 2.0e-4
+
+quantization:
+  bits: 4
+  quantization_type: nf4
+```
+
+```bash
+ludwig train --config sentiment_adapter.yaml --dataset sentiment.csv \
+             --output_directory ./sentiment_model
+```
+
+---
+
+## Adapter 2: Topic
+
+```yaml
+# topic_adapter.yaml — same base model, different adapter name
+model_type: llm
+base_model: meta-llama/Llama-3.1-8B
+
+adapters:
+  adapters:
+    topic:
+      type: lora
+      r: 8
+      alpha: 16
+      target_modules: ["q_proj", "v_proj"]
+  active: topic
+
+input_features:
+  - name: text
+    type: text
+
+output_features:
+  - name: topic
+    type: category
+
+trainer:
+  type: finetune
+  epochs: 3
+  batch_size: 8
+  learning_rate: 2.0e-4
+
+quantization:
+  bits: 4
+  quantization_type: nf4
+```
+
+```bash
+ludwig train --config topic_adapter.yaml --dataset topics.csv \
+             --output_directory ./topic_model
+```
+
+---
+
+## Merging with TIES
+
+```yaml
+# merged_adapter.yaml
+model_type: llm
+base_model: meta-llama/Llama-3.1-8B
+
+adapters:
+  adapters:
+    sentiment:
+      type: lora
+      r: 8
+    topic:
+      type: lora
+      r: 8
+  merge:
+    name: sentiment_topic_merged
+    sources: [sentiment, topic]
+    weights: [0.5, 0.5]
+    combination_type: ties   # resolves sign conflicts between adapters
+    density: 0.7             # keep 70% of deltas
+
+  active: sentiment_topic_merged
+```
+
+```python
+from ludwig.api import LudwigModel
+
+# Load sentiment model and add topic adapter weights
+model = LudwigModel.load("sentiment_model/experiment_run/model")
+# (In practice, load adapters programmatically via PEFT's load_adapter)
+
+# Or configure and load merged model directly
+merged_model = LudwigModel(config="merged_adapter.yaml")
+```
+
+---
+
+## Evaluating the merged model
+
+```python
+import pandas as pd
+from ludwig.api import LudwigModel
+
+model = LudwigModel.load("merged_model/experiment_run/model")
+peft_model = model.model.model
+
+# Test sentiment
+peft_model.set_adapter("sentiment_topic_merged")
+test_sentiment = pd.DataFrame({"text": ["This is fantastic!", "I hate it."]})
+preds, _ = model.predict(dataset=test_sentiment)
+print("Sentiment:", preds["sentiment_predictions"].tolist())
+
+# Test topic
+test_topic = pd.DataFrame({"text": ["New processor breaks speed records.", "Team wins playoff game."]})
+preds, _ = model.predict(dataset=test_topic)
+print("Topic:", preds["topic_predictions"].tolist())
+```
+
+---
+
+## Combination strategy comparison
+
+| Strategy | When to use |
+|----------|-------------|
+| `linear` | Similar tasks, same training distribution |
+| `ties` | Conflicting tasks (different domains, risk of sign conflicts) |
+| `dare_linear` | Memory-constrained; want sparse merged weights |
+| `dare_ties` | Both sign conflicts and memory constraints |
+
+---
+
+## See also
+
+- [Multi-Adapter PEFT user guide](../user_guide/llms/multi_adapter.md)
+- [LLM Fine-Tuning](llms/llm_finetuning.md) — single-adapter fine-tuning
+- [VLM Fine-Tuning](vlm_finetuning.md) — multi-adapter for vision-language models

--- a/docs/examples/ray_serve.md
+++ b/docs/examples/ray_serve.md
@@ -1,0 +1,240 @@
+---
+description: Deploy Ludwig models at scale with Ray Serve (autoscaling multi-replica) or KServe (Kubernetes Open Inference Protocol v2) for production ML serving.
+---
+
+# Ray Serve and KServe Deployment
+
+Ludwig models can be deployed to production with:
+
+- **Ray Serve** — autoscaling multi-replica deployment on a Ray cluster
+- **KServe** — Kubernetes-native serving via the Open Inference Protocol v2
+
+Both expose the same `/predict` payload interface as the built-in FastAPI server, so your
+client code works unchanged across local, Ray Serve, and KServe deployments.
+
+For general serving options (local FastAPI, vLLM) see [Serving Ludwig Models](../user_guide/serving.md).
+
+---
+
+## Ray Serve
+
+### Install
+
+```bash
+pip install "ludwig[distributed]"  # includes ray[serve]
+```
+
+### Deploy
+
+=== "Python API"
+
+    ```python
+    import ray
+    from ray import serve
+    from ludwig.serve_ray_serve import deploy_ludwig_model
+
+    ray.init(ignore_reinit_error=True)
+
+    handle = deploy_ludwig_model(
+        model_path="results/experiment_run/model",
+        name="sentiment",
+        num_replicas=2,
+        ray_actor_options={"num_gpus": 1},  # omit for CPU
+    )
+
+    print("Deployment live at: http://localhost:8000/sentiment")
+    ```
+
+=== "CLI (deploy.py)"
+
+    ```bash
+    # Two GPU replicas on port 8080
+    python examples/serving/ray_serve/deploy.py \
+        --model_path ./results/my_model \
+        --name sentiment \
+        --num_replicas 2 \
+        --gpu \
+        --port 8080 \
+        --block
+    ```
+
+### Send predictions
+
+```bash
+# Single record
+curl -X POST http://localhost:8000/sentiment \
+  -H "Content-Type: application/json" \
+  -d '{"text": "I love this product!", "stars": 5}'
+
+# Batch (list of records)
+curl -X POST http://localhost:8000/sentiment \
+  -H "Content-Type: application/json" \
+  -d '[{"text": "great"}, {"text": "terrible"}]'
+```
+
+Python client:
+
+```python
+import httpx
+import json
+
+url = "http://localhost:8000/sentiment"
+
+# Single record
+response = httpx.post(url, json={"text": "Amazing product, highly recommend!"})
+print(response.json())
+
+# Batch
+records = [{"text": "great"}, {"text": "terrible"}, {"text": "okay"}]
+response = httpx.post(url, json=records)
+print(response.json())
+```
+
+### Autoscaling
+
+Ray Serve supports autoscaling out of the box. Modify `deploy_ludwig_model` to pass
+`autoscaling_config`:
+
+```python
+from ray.serve.config import AutoscalingConfig
+from ludwig.serve_ray_serve import make_ludwig_deployment_class
+
+DeploymentClass = make_ludwig_deployment_class(
+    num_replicas=1,
+    ray_actor_options={"num_gpus": 1},
+)
+
+# Autoscale between 1 and 10 replicas based on queue length
+app = DeploymentClass.options(
+    autoscaling_config=AutoscalingConfig(
+        min_replicas=1,
+        max_replicas=10,
+        target_num_ongoing_requests_per_replica=5,
+    )
+).bind("results/experiment_run/model")
+
+serve.run(app, name="sentiment")
+```
+
+### Traffic splitting (A/B testing)
+
+```python
+from ray import serve
+from ludwig.serve_ray_serve import make_ludwig_deployment_class
+
+ModelV1 = make_ludwig_deployment_class(num_replicas=1)
+ModelV2 = make_ludwig_deployment_class(num_replicas=1)
+
+app_v1 = ModelV1.bind("results/model_v1")
+app_v2 = ModelV2.bind("results/model_v2")
+
+# Route 80% to v1, 20% to v2
+serve.run(
+    {"v1": serve.options(route_prefix="/v1")(app_v1),
+     "v2": serve.options(route_prefix="/v2")(app_v2)},
+)
+```
+
+---
+
+## KServe
+
+KServe implements the [Open Inference Protocol v2](https://kserve.github.io/website/modelserving/data_plane/v2_protocol/)
+for Kubernetes-native ML serving.
+
+### Install
+
+```bash
+pip install kserve
+```
+
+### Serve locally
+
+```bash
+python -m ludwig.serve_kserve \
+    --model_name sentiment \
+    --model_path results/experiment_run/model
+```
+
+Or with Python:
+
+```python
+from ludwig.serve_kserve import create_kserve_model_server
+
+server = create_kserve_model_server(
+    model_name="sentiment",
+    model_path="results/experiment_run/model",
+)
+server.start([server.model])
+```
+
+### Send v2 protocol requests
+
+```bash
+# Health check
+curl http://localhost:8080/v2/health/live
+
+# Model metadata
+curl http://localhost:8080/v2/models/sentiment
+
+# Inference (v2 input format)
+curl -X POST http://localhost:8080/v2/models/sentiment/infer \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputs": [
+      {"name": "text", "shape": [1], "datatype": "BYTES", "data": ["I love this!"]},
+      {"name": "stars", "shape": [1], "datatype": "INT32", "data": [5]}
+    ]
+  }'
+```
+
+### Deploy on Kubernetes with KServe
+
+Create a `InferenceService` manifest:
+
+```yaml
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: ludwig-sentiment
+spec:
+  predictor:
+    containers:
+      - name: predictor
+        image: ludwigai/ludwig:latest
+        command: ["python", "-m", "ludwig.serve_kserve"]
+        args:
+          - --model_name=sentiment
+          - --model_path=/mnt/models
+        volumeMounts:
+          - name: model-volume
+            mountPath: /mnt/models
+    volumes:
+      - name: model-volume
+        persistentVolumeClaim:
+          claimName: ludwig-models-pvc
+```
+
+```bash
+kubectl apply -f inference_service.yaml
+kubectl get inferenceservice ludwig-sentiment
+```
+
+---
+
+## Choosing between serving options
+
+| Option | Scale | Protocol | Best for |
+|--------|-------|----------|----------|
+| `ludwig serve` (FastAPI) | Single process | REST JSON | Development, simple APIs |
+| Ray Serve | Multi-replica, autoscaling | REST JSON | Production on Ray clusters |
+| KServe | Kubernetes-native | OIP v2 + REST | Enterprise Kubernetes |
+| `ludwig serve` (vLLM) | GPU-optimized | OpenAI-compatible | LLM serving |
+
+---
+
+## See also
+
+- [Serving Ludwig Models](../user_guide/serving.md) — FastAPI and vLLM serving
+- [Distributed training on Ray](../user_guide/distributed_training/index.md) — train on a Ray cluster
+- [Model Export](../user_guide/model_export.md) — export to ONNX or TorchScript before serving

--- a/docs/examples/vlm_finetuning.md
+++ b/docs/examples/vlm_finetuning.md
@@ -1,0 +1,207 @@
+---
+description: End-to-end example of fine-tuning a Vision-Language Model (VLM) like Qwen2-VL on a visual question answering dataset using Ludwig and QLoRA.
+---
+
+# VLM Fine-Tuning
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ludwig-ai/ludwig/blob/main/examples/vlm_finetuning/vlm_finetuning.ipynb)
+
+This example fine-tunes **Qwen2-VL-7B-Instruct** on a Visual Question Answering (VQA) task.
+The model learns to answer natural-language questions about images using 4-bit QLoRA, so it
+fits on a single 24 GB GPU.
+
+For the full user guide see [VLM Fine-Tuning](../user_guide/llms/vlm_finetuning.md).
+
+---
+
+## Dataset
+
+The example uses a VQA dataset formatted as a CSV with three columns:
+
+| Column | Description |
+|--------|-------------|
+| `image_path` | Path to image file |
+| `question` | Natural-language question about the image |
+| `answer` | Expected answer (fine-tuning target) |
+
+```csv
+image_path,question,answer
+/data/dog.jpg,What breed is this dog?,Golden Retriever
+/data/chart.png,What is the peak value in the chart?,42
+/data/receipt.jpg,What is the total amount?,$ 18.50
+```
+
+### Using a HuggingFace VQA dataset
+
+You can also use datasets from HuggingFace:
+
+```python
+from datasets import load_dataset
+import pandas as pd
+from pathlib import Path
+
+# Load VQA-v2 (small split for demo)
+ds = load_dataset("HuggingFaceM4/VQAv2", split="validation[:2000]", trust_remote_code=True)
+
+# Save images locally and build CSV
+img_dir = Path("vqa_images")
+img_dir.mkdir(exist_ok=True)
+
+rows = []
+for i, item in enumerate(ds):
+    img_path = img_dir / f"{i}.jpg"
+    item["image"].save(img_path)
+    rows.append({
+        "image_path": str(img_path),
+        "question": item["question"],
+        "answer": item["multiple_choice_answer"],
+    })
+
+df = pd.DataFrame(rows)
+df.to_csv("vqa_dataset.csv", index=False)
+```
+
+---
+
+## Configuration
+
+```yaml
+# vlm_config.yaml
+model_type: llm
+base_model: Qwen/Qwen2-VL-7B-Instruct
+
+is_multimodal: true
+trust_remote_code: true
+
+input_features:
+  - name: image_path
+    type: image
+  - name: question
+    type: text
+
+output_features:
+  - name: answer
+    type: text
+
+adapter:
+  type: lora
+  r: 16
+  alpha: 32
+  target_modules: ["q_proj", "v_proj"]
+
+trainer:
+  type: finetune
+  epochs: 3
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  learning_rate: 2.0e-5
+  learning_rate_scheduler:
+    decay: cosine
+    warmup_fraction: 0.03
+
+quantization:
+  bits: 4
+  quantization_type: nf4
+  compute_dtype: bfloat16
+
+generation:
+  max_new_tokens: 256
+  temperature: 0.0
+```
+
+---
+
+## Training
+
+```bash
+pip install "ludwig[llm]"
+huggingface-cli login  # needed for gated models
+
+ludwig train \
+  --config vlm_config.yaml \
+  --dataset vqa_dataset.csv \
+  --output_directory ./results
+```
+
+Or with the Python API:
+
+```python
+from ludwig.api import LudwigModel
+
+model = LudwigModel(config="vlm_config.yaml")
+results = model.train(
+    dataset="vqa_dataset.csv",
+    output_directory="./results",
+    skip_save_processed_input=True,
+)
+print(f"Model saved to: {results.output_directory}")
+```
+
+---
+
+## Inference
+
+```python
+import pandas as pd
+from ludwig.api import LudwigModel
+
+model = LudwigModel.load("results/experiment_run/model")
+
+questions = pd.DataFrame([
+    {"image_path": "test1.jpg", "question": "What color is the car?"},
+    {"image_path": "test2.jpg", "question": "How many people are visible?"},
+])
+
+predictions, _ = model.predict(dataset=questions)
+for q, a in zip(questions["question"], predictions["answer_predictions"]):
+    print(f"Q: {q}")
+    print(f"A: {a}\n")
+```
+
+---
+
+## Multi-GPU training
+
+For larger models or datasets, scale to multiple GPUs with Ray:
+
+```yaml
+# vlm_config_distributed.yaml — append to the config above
+backend:
+  type: ray
+  trainer:
+    use_gpu: true
+    num_workers: 4
+    resources_per_worker:
+      GPU: 1
+```
+
+```bash
+ray start --head
+ludwig train --config vlm_config_distributed.yaml --dataset vqa_dataset.csv
+```
+
+---
+
+## Alternative VLM base models
+
+Swap `base_model` for any HuggingFace `Vision2Seq` model:
+
+```yaml
+# LLaVA 1.5
+base_model: llava-hf/llava-1.5-7b-hf
+is_multimodal: true
+trust_remote_code: false  # LLaVA doesn't need this
+
+# InternVL2 (strong on document tasks)
+base_model: OpenGVLab/InternVL2-8B
+is_multimodal: true
+trust_remote_code: true
+```
+
+---
+
+## See also
+
+- [VLM Fine-Tuning user guide](../user_guide/llms/vlm_finetuning.md) — full reference
+- [LLM Fine-Tuning](llms/llm_finetuning.md) — text-only LLM fine-tuning
+- [Multi-adapter PEFT](../user_guide/llms/multi_adapter.md) — merge specialized VLM adapters

--- a/docs/user_guide/llms/config_generation.md
+++ b/docs/user_guide/llms/config_generation.md
@@ -1,0 +1,157 @@
+---
+description: Generate Ludwig YAML configs from plain English task descriptions using an LLM. Describe your ML task and get a validated config you can train immediately.
+---
+
+# LLM Config Generation
+
+Ludwig can generate a complete, validated YAML configuration from a plain-English description of
+your machine learning task. This is useful for rapid prototyping, onboarding new users, or
+automating ML pipeline setup.
+
+## How it works
+
+`ludwig.config_generation.generate_config` sends your task description to Claude or GPT-4, along
+with a compact representation of Ludwig's configuration schema. The LLM returns a JSON config
+that is then validated with full Pydantic validation before being returned to you.
+
+## Prerequisites
+
+Install an LLM provider SDK:
+
+```bash
+pip install anthropic    # for Claude (default)
+# or
+pip install openai       # for GPT-4o
+```
+
+Set your API key:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+# or
+export OPENAI_API_KEY=sk-...
+```
+
+## Python API
+
+```python
+from ludwig.config_generation import generate_config
+
+config = generate_config(
+    "I have a CSV with columns: age (number), annual_income (number), "
+    "num_purchases (integer), and days_since_last_purchase (integer). "
+    "I want to predict whether a customer will churn (binary: 0 or 1)."
+)
+
+# config is a validated dict you can pass directly to LudwigModel
+from ludwig.api import LudwigModel
+model = LudwigModel(config=config)
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `task_description` | — | Plain-English description of your ML task |
+| `model` | `claude-sonnet-4-20250514` | LLM to use. Claude models start with `claude-`, OpenAI with `gpt-` |
+| `api_key` | `None` | API key; defaults to reading `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` env vars |
+| `validate` | `True` | Whether to validate the generated config with Pydantic before returning |
+
+### Example descriptions
+
+**Tabular classification:**
+```python
+config = generate_config(
+    "Predict loan default from: age (number), income (number), "
+    "debt_to_income_ratio (number), loan_purpose (category), "
+    "credit_score (number). Target: defaulted (binary)."
+)
+```
+
+**Text classification:**
+```python
+config = generate_config(
+    "I have product reviews (text) and want to classify sentiment "
+    "as positive, negative, or neutral (category)."
+)
+```
+
+**Multi-output regression:**
+```python
+config = generate_config(
+    "Given wine chemical properties (fixed_acidity, volatile_acidity, "
+    "citric_acid, pH — all numbers), predict quality_score (number 1-10) "
+    "and whether the wine is good (binary)."
+)
+```
+
+**Multimodal:**
+```python
+config = generate_config(
+    "I have a dataset of product listings with: title (text), "
+    "image_path (image), and price (number). "
+    "Predict whether the listing will sell within 7 days (binary)."
+)
+```
+
+## CLI
+
+```bash
+ludwig generate_config "predict house price from bedrooms, sqft, location"
+```
+
+Save to file:
+```bash
+ludwig generate_config "classify email as spam or ham" --output config.yaml
+```
+
+Use GPT-4o:
+```bash
+ludwig generate_config --model gpt-4o "predict churn from user activity metrics"
+```
+
+## Inspecting and editing the generated config
+
+Always review the generated config before training. Print it as YAML:
+
+```python
+import yaml
+from ludwig.config_generation import generate_config
+
+config = generate_config("predict house price from bedrooms, sqft, location, year_built")
+print(yaml.dump(config, default_flow_style=False, sort_keys=False))
+```
+
+The generated config is a standard Ludwig config dict — edit it freely before passing to
+`LudwigModel`.
+
+## Training on the generated config
+
+```python
+import pandas as pd
+from ludwig.api import LudwigModel
+from ludwig.config_generation import generate_config
+
+config = generate_config(
+    "predict customer churn from age, income, num_purchases, days_since_last_purchase"
+)
+
+df = pd.read_csv("customers.csv")
+model = LudwigModel(config=config)
+results = model.train(dataset=df, output_directory="./results")
+```
+
+## Limitations
+
+- Generated configs may need adjustment for domain-specific encoders (e.g., specifying
+  `pretrained_model_name_or_path` for text encoders).
+- LLM-generated configs are validated but not guaranteed to be optimal — treat them as a
+  starting point for hyperparameter tuning.
+- Image, audio, and time series features require correct file paths in the dataset.
+- Very complex configs (multi-adapter PEFT, custom backends) may require manual editing.
+
+## See also
+
+- [Configuration reference](../../configuration/index.md) — full YAML schema
+- [LLM Config Generation example](../../examples/config_generation.md) — runnable walkthrough
+- [Hyperparameter optimization](../../user_guide/hyperopt.md) — tune the generated config

--- a/docs/user_guide/llms/index.md
+++ b/docs/user_guide/llms/index.md
@@ -48,3 +48,10 @@ In-context learning is most commonly useful in the following situations:
 In-context learning doesn't require any training in order to make use of it, so it's a natural place to start when applying an LLM to a task. The primarily limitation of ICL is the context length of the LLM itself (how many "tokens" can be put into the prompt). It should be noted that even for models
 that accept very long contexts, there is often a degradation in performance as the prompt increases in length (see: [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)). As such, if the the context needed to respond to the prompt is very large, it may be worth
 exploring fine-tuning instead.
+
+## Additional Topics
+
+- [**VLM Fine-Tuning**](vlm_finetuning.md) — Fine-tune Vision-Language Models (Qwen2-VL, LLaVA) on image+text tasks
+- [**Multi-Adapter PEFT**](multi_adapter.md) — Merge multiple LoRA adapters with TIES, DARE, or linear combining
+- [**LLM Config Generation**](config_generation.md) — Generate a valid Ludwig config from a plain-English task description
+- [**Structured Output**](structured_output.md) — Constrained decoding for guaranteed valid category and JSON output

--- a/docs/user_guide/llms/multi_adapter.md
+++ b/docs/user_guide/llms/multi_adapter.md
@@ -1,0 +1,150 @@
+---
+description: Train multiple LoRA adapters on the same base model and merge them with TIES, DARE, or linear combining. Use multi-adapter PEFT for domain specialization, A/B testing, and efficient model ensembles.
+---
+
+# Multi-Adapter PEFT
+
+Ludwig supports training and deploying **multiple named PEFT adapters** on the same base model.
+This enables domain specialization, adapter ensembles, and efficient A/B testing — all without
+duplicating the large base model weights.
+
+## When to use multi-adapter PEFT
+
+| Use case | Description |
+|----------|-------------|
+| **Domain specialization** | Train a "coding" adapter and a "chat" adapter separately, then merge for a model that does both |
+| **A/B testing** | Switch between adapters at inference time without reloading the base model |
+| **Continual learning** | Add a new adapter for each new task without forgetting previous ones |
+| **Adapter ensembles** | Merge adapters trained on different data splits for better generalization |
+
+## Configuration
+
+Use `adapters:` (plural) instead of the singular `adapter:` to define multiple named adapters:
+
+```yaml
+model_type: llm
+base_model: meta-llama/Llama-3.1-8B
+
+adapters:
+  adapters:
+    coding:
+      type: lora
+      r: 16
+      alpha: 32
+      target_modules: ["q_proj", "v_proj"]
+    chat:
+      type: lora
+      r: 8
+      alpha: 16
+      target_modules: ["q_proj", "v_proj"]
+  active: coding  # which adapter is used at inference time
+```
+
+`adapter:` and `adapters:` are mutually exclusive — existing single-adapter configs work
+unchanged.
+
+## Merging adapters
+
+After training, merge multiple adapters into one using PEFT's `add_weighted_adapter()`:
+
+```yaml
+adapters:
+  adapters:
+    coding:
+      type: lora
+      r: 16
+    chat:
+      type: lora
+      r: 8
+  merge:
+    name: coding_chat  # name of the merged adapter
+    sources: [coding, chat]
+    weights: [0.7, 0.3]  # relative weights; will be normalised
+    combination_type: ties
+    density: 0.7         # fraction of deltas to retain (for TIES/DARE)
+  active: coding_chat
+```
+
+### Combination strategies
+
+| Strategy | Paper | Description |
+|----------|-------|-------------|
+| `linear` | — | Weighted sum of LoRA weight deltas. Fast, no pruning. |
+| `svd` | — | SVD-based merge; reduces rank after combining |
+| `ties` | [Yadav et al., NeurIPS 2023](https://arxiv.org/abs/2306.01708) | Resolves sign conflicts between adapters before summing deltas |
+| `dare_linear` | [Yu et al., ICML 2024](https://arxiv.org/abs/2402.03432) | Prunes fraction `(1-density)` of deltas, then linear merge |
+| `dare_ties` | [Yu et al., ICML 2024](https://arxiv.org/abs/2402.03432) | Prunes deltas, then TIES sign-conflict resolution |
+| `magnitude_prune` | — | Keeps top-magnitude deltas before merging |
+
+**Picking a strategy:**
+
+- Start with `linear` — it's fastest and often competitive
+- Use `ties` when adapters were trained on conflicting tasks (coding vs chat, different languages)
+- Use `dare_linear` or `dare_ties` when you want sparse, memory-efficient merged adapters
+- `density: 0.7` means keep 70% of deltas; lower values produce sparser adapters
+
+## Training multiple adapters
+
+Train adapters separately and merge at the end:
+
+```python
+from ludwig.api import LudwigModel
+import pandas as pd
+
+# Train coding adapter
+config_coding = {
+    "model_type": "llm",
+    "base_model": "meta-llama/Llama-3.1-8B",
+    "adapters": {"adapters": {"coding": {"type": "lora", "r": 16}}},
+    "input_features": [{"name": "prompt", "type": "text"}],
+    "output_features": [{"name": "response", "type": "text"}],
+    "trainer": {"type": "finetune", "epochs": 3},
+}
+model = LudwigModel(config=config_coding)
+model.train(dataset="coding_dataset.csv", output_directory="./coding_model")
+
+# Train chat adapter
+config_chat = {**config_coding}
+config_chat["adapters"]["adapters"] = {"chat": {"type": "lora", "r": 8}}
+model2 = LudwigModel(config=config_chat)
+model2.train(dataset="chat_dataset.csv", output_directory="./chat_model")
+```
+
+## Switching adapters at inference time
+
+With multiple adapters loaded, switch between them without reloading the model:
+
+```python
+from ludwig.api import LudwigModel
+
+model = LudwigModel.load("results/multi_adapter_model")
+
+# Access the underlying PEFT model
+peft_model = model.model.model
+
+# Switch active adapter
+peft_model.set_adapter("coding")
+coding_preds, _ = model.predict(dataset=coding_test_df)
+
+peft_model.set_adapter("chat")
+chat_preds, _ = model.predict(dataset=chat_test_df)
+```
+
+## Memory considerations
+
+Multi-adapter PEFT loads all adapter weights simultaneously but shares the base model:
+
+| Setup | Memory overhead vs single adapter |
+|-------|----------------------------------|
+| 2 × LoRA-r8 adapters | ~2× adapter memory (small vs base model) |
+| Merged adapter | No overhead — same as single adapter |
+| Enabled adapter switching | All adapter weights in VRAM |
+
+For large numbers of adapters, consider training sequentially and using `merge:` to combine
+them — the merged adapter has the same memory footprint as a single adapter.
+
+## See also
+
+- [LLM Fine-Tuning](finetuning.md) — single-adapter PEFT with LoRA/QLoRA
+- [LLM configuration reference](../../configuration/large_language_model.md#multi-adapter-peft) — full YAML schema
+- [Multi-adapter example](../../examples/multi_adapter.md) — runnable walkthrough

--- a/docs/user_guide/llms/vlm_finetuning.md
+++ b/docs/user_guide/llms/vlm_finetuning.md
@@ -1,0 +1,190 @@
+---
+description: Fine-tune Vision-Language Models (VLMs) like Qwen2-VL and LLaVA on image+text tasks using Ludwig. Covers QLoRA, multimodal preprocessing, and VQA datasets.
+---
+
+# Vision-Language Model Fine-Tuning
+
+Ludwig supports fine-tuning **Vision-Language Models (VLMs)** — pretrained models that jointly reason
+over images and text. This lets you adapt models like Qwen2-VL, LLaVA, or Idefics to your own
+image+text tasks without writing any custom training code.
+
+## What is a VLM?
+
+A Vision-Language Model combines a vision encoder (typically a ViT or CLIP-style model) with a
+large language model backbone. The model receives both image patches and text tokens as input and
+generates text as output. Common tasks include:
+
+- **Visual Question Answering (VQA)** — answer natural-language questions about images
+- **Image Captioning** — generate descriptions of images
+- **Instruction following on images** — follow complex instructions that reference visual content
+- **Document understanding** — parse charts, tables, or screenshots
+
+## Prerequisites
+
+```bash
+pip install "ludwig[llm]"
+```
+
+To use models from HuggingFace Hub that require gated access (like Llama-based VLMs):
+
+```bash
+huggingface-cli login
+```
+
+## Dataset format
+
+VLM fine-tuning requires a CSV with at least:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `image_path` | string | Absolute or relative path to an image file |
+| `question` | string | Instruction or question about the image |
+| `answer` | string | Expected response (fine-tuning target) |
+
+```csv
+image_path,question,answer
+/data/dog.jpg,What breed is this dog?,Golden Retriever
+/data/chart.png,What is the highest value on the y-axis?,42
+```
+
+## Configuration
+
+### Minimal config (Qwen2-VL)
+
+```yaml
+model_type: llm
+base_model: Qwen/Qwen2-VL-7B-Instruct
+
+# Enable multimodal (VLM) mode — required for image+text models
+is_multimodal: true
+trust_remote_code: true
+
+input_features:
+  - name: image_path
+    type: image
+  - name: question
+    type: text
+
+output_features:
+  - name: answer
+    type: text
+
+adapter:
+  type: lora
+  r: 16
+  alpha: 32
+  target_modules: ["q_proj", "v_proj"]
+
+trainer:
+  type: finetune
+  epochs: 3
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  learning_rate: 2.0e-5
+  learning_rate_scheduler:
+    decay: cosine
+    warmup_fraction: 0.03
+
+# 4-bit quantisation to fit a 7B VLM on a single 24 GB GPU
+quantization:
+  bits: 4
+  quantization_type: nf4
+  compute_dtype: bfloat16
+
+generation:
+  max_new_tokens: 256
+  temperature: 0.0
+```
+
+The key parameter is `is_multimodal: true`. When set, Ludwig:
+
+1. Loads the model with `AutoModelForVision2Seq` instead of `AutoModelForCausalLM`
+2. Loads the corresponding multimodal processor (`AutoProcessor`) for joint text+image tokenisation
+3. Handles image patch extraction and interleaving with text tokens automatically
+
+### Supported base models
+
+Any HuggingFace `Vision2Seq` model works as a base model:
+
+| Model | HuggingFace ID | Notes |
+|-------|---------------|-------|
+| Qwen2-VL 7B | `Qwen/Qwen2-VL-7B-Instruct` | Strong performance, requires `trust_remote_code: true` |
+| Qwen2-VL 72B | `Qwen/Qwen2-VL-72B-Instruct` | Best quality, needs 2× A100 with QLoRA |
+| LLaVA 1.5 | `llava-hf/llava-1.5-7b-hf` | Widely used baseline |
+| LLaVA-NeXT | `llava-hf/llava-v1.6-mistral-7b-hf` | Improved resolution handling |
+| Idefics-9B | `HuggingFaceM4/idefics-9b-instruct` | Multi-image support |
+| InternVL2 | `OpenGVLab/InternVL2-8B` | Strong on document understanding |
+
+## Training
+
+```bash
+ludwig train \
+  --config vlm_config.yaml \
+  --dataset vqa_dataset.csv \
+  --output_directory ./results
+```
+
+Or via Python:
+
+```python
+from ludwig.api import LudwigModel
+
+model = LudwigModel(config="vlm_config.yaml")
+results = model.train(
+    dataset="vqa_dataset.csv",
+    output_directory="./results",
+    skip_save_processed_input=True,  # images are large; skip caching
+)
+print(f"Model saved to: {results.output_directory}")
+```
+
+## Inference
+
+After training, load the fine-tuned model and run predictions:
+
+```python
+import pandas as pd
+from ludwig.api import LudwigModel
+
+model = LudwigModel.load("results/experiment_run/model")
+
+test_data = pd.DataFrame([
+    {"image_path": "/data/test1.jpg", "question": "What color is the car?"},
+    {"image_path": "/data/test2.jpg", "question": "How many people are in this image?"},
+])
+predictions, _ = model.predict(dataset=test_data)
+print(predictions["answer_predictions"])
+```
+
+## Memory requirements
+
+| Setup | GPU Memory | Recommended GPU |
+|-------|-----------|-----------------|
+| Qwen2-VL-7B, QLoRA 4-bit | ~16 GB | RTX 4090, A100-40GB |
+| Qwen2-VL-7B, full fine-tune | ~48 GB | 2× A100-40GB |
+| Qwen2-VL-72B, QLoRA 4-bit | ~80 GB | 2× A100-80GB |
+
+## Distributed training on Ray
+
+For large VLMs or large datasets, use Ray for multi-GPU training:
+
+```yaml
+backend:
+  type: ray
+  trainer:
+    use_gpu: true
+    num_workers: 2
+    resources_per_worker:
+      GPU: 1
+```
+
+```bash
+ludwig train --config vlm_config.yaml --dataset vqa.csv
+```
+
+## See also
+
+- [LLM Fine-Tuning guide](finetuning.md) — general LLM fine-tuning with LoRA/QLoRA
+- [VLM fine-tuning example](../../examples/vlm_finetuning.md) — end-to-end walkthrough
+- [Multi-adapter PEFT](multi_adapter.md) — merge multiple VLM adapters
+- [LLM configuration reference](../../configuration/large_language_model.md)

--- a/docs/user_guide/model_inspector.md
+++ b/docs/user_guide/model_inspector.md
@@ -1,0 +1,144 @@
+---
+description: Use ModelInspector to inspect trained Ludwig models — collect weights, generate summaries, and estimate feature importance without writing custom PyTorch code.
+---
+
+# Model Inspector
+
+`ModelInspector` provides introspection utilities for analyzing trained Ludwig models. It
+exposes weight collection, architecture summaries, and feature importance proxies without
+requiring you to interact with raw PyTorch module trees.
+
+## Getting a ModelInspector
+
+After training, obtain the inspector from a loaded model:
+
+```python
+from ludwig.api import LudwigModel
+from ludwig.model_inspector import ModelInspector
+
+model = LudwigModel.load("results/experiment_run/model")
+
+inspector = ModelInspector(
+    model=model.model,
+    config=model.config.to_dict(),
+    training_set_metadata=model.training_set_metadata,
+)
+```
+
+## Model summary
+
+`model_summary()` returns parameter counts, memory footprint, layer inventory, and high-level
+architecture information:
+
+```python
+summary = inspector.model_summary()
+print(summary)
+# {
+#   'total_parameters': 4_831_042,
+#   'trainable_parameters': 4_831_042,
+#   'frozen_parameters': 0,
+#   'model_size_mb': 18.43,
+#   'layer_counts': {'Linear': 24, 'LayerNorm': 8, 'ReLU': 12, ...},
+#   'model_type': 'ecd',
+#   'combiner_type': 'concat',
+#   'num_input_features': 5,
+#   'num_output_features': 2,
+# }
+```
+
+| Field | Description |
+|-------|-------------|
+| `total_parameters` | Total number of parameters (trainable + frozen) |
+| `trainable_parameters` | Parameters that will receive gradient updates |
+| `frozen_parameters` | Parameters frozen (e.g., pretrained encoder backbone) |
+| `model_size_mb` | Approximate memory footprint in MB |
+| `layer_counts` | Count of each PyTorch module type in the model |
+| `model_type` | `ecd` or `llm` |
+| `combiner_type` | The combiner used (e.g., `concat`, `transformer`, `hypernetwork`) |
+| `num_input_features` | Number of input feature encoders |
+| `num_output_features` | Number of output feature decoders |
+
+## Collecting weights
+
+`collect_weights()` returns parameter tensors as a list of metadata dicts. Use this for
+weight analysis, debugging gradient flow, or building custom interpretability tools:
+
+```python
+# All parameters
+weights = inspector.collect_weights()
+for w in weights[:5]:
+    print(w)
+# {'name': 'input_features.text.encoder.weight', 'shape': [256, 128],
+#  'dtype': 'torch.float32', 'requires_grad': True, 'num_elements': 32768}
+
+# Specific parameters by name
+encoder_weights = inspector.collect_weights(
+    tensor_names=["input_features.text.encoder.weight"]
+)
+```
+
+Each entry is a dict with:
+
+| Key | Description |
+|-----|-------------|
+| `name` | Fully qualified parameter name (PyTorch `named_parameters()` format) |
+| `shape` | List of dimension sizes |
+| `dtype` | PyTorch dtype as string |
+| `requires_grad` | Whether the parameter is trainable |
+| `num_elements` | Total number of scalar elements |
+
+!!! note
+    `collect_weights()` returns metadata only, not the actual tensor values, to avoid
+    copying large tensors unnecessarily. Access the underlying tensor directly with
+    `dict(model.model.named_parameters())[name]`.
+
+## Feature importance proxy
+
+`feature_importance_proxy()` estimates feature importance from encoder weight magnitudes.
+This is a rough proxy — for rigorous feature importance use SHAP or Ludwig's
+`explain` module.
+
+```python
+importance = inspector.feature_importance_proxy()
+print(importance)
+# {'text_description': 0.92, 'age': 0.45, 'income': 1.0, 'category_col': 0.31}
+```
+
+Scores are normalized to `[0, 1]`. Higher means the encoder has larger weight magnitudes,
+which loosely correlates with the feature being heavily used by the model.
+
+## Practical use cases
+
+### Checking how many parameters are frozen
+
+Useful when fine-tuning with frozen encoders:
+
+```python
+summary = inspector.model_summary()
+frozen_pct = summary["frozen_parameters"] / summary["total_parameters"] * 100
+print(f"{frozen_pct:.1f}% of parameters are frozen")
+```
+
+### Finding large layers
+
+```python
+weights = inspector.collect_weights()
+large = sorted(weights, key=lambda w: w["num_elements"], reverse=True)
+for w in large[:10]:
+    print(f"{w['name']}: {w['num_elements']:,} params  shape={w['shape']}")
+```
+
+### Quick sanity check after fine-tuning
+
+```python
+summary = inspector.model_summary()
+assert summary["trainable_parameters"] > 0, "No trainable parameters!"
+assert summary["model_size_mb"] < 2000, f"Model too large: {summary['model_size_mb']} MB"
+print(f"Model OK: {summary['trainable_parameters']:,} trainable params")
+```
+
+## See also
+
+- [LudwigModel Python API](api/LudwigModel.md) — `.train()`, `.predict()`, `.evaluate()`
+- [Model Export](model_export.md) — export to ONNX, TorchScript, HuggingFace Hub
+- [Visualizations](visualizations.md) — training curves, confusion matrices, feature rankings

--- a/docs/user_guide/serving.md
+++ b/docs/user_guide/serving.md
@@ -149,3 +149,103 @@ response = client.chat.completions.create(
 )
 print(response.choices[0].message.content)
 ```
+
+---
+
+## Ray Serve
+
+[Ray Serve](https://docs.ray.io/en/latest/serve/index.html) provides autoscaling multi-replica
+serving on a Ray cluster. Use this for production deployments where you need horizontal scaling
+or traffic splitting.
+
+### Install
+
+```bash
+pip install "ludwig[distributed]"
+```
+
+### Deploy
+
+```python
+import ray
+from ludwig.serve_ray_serve import deploy_ludwig_model
+
+ray.init(ignore_reinit_error=True)
+
+handle = deploy_ludwig_model(
+    model_path="results/experiment_run/model",
+    name="sentiment",
+    num_replicas=2,
+    ray_actor_options={"num_gpus": 1},  # omit for CPU
+)
+```
+
+Or via the CLI helper:
+
+```bash
+python examples/serving/ray_serve/deploy.py \
+    --model_path ./results/my_model \
+    --num_replicas 2 \
+    --gpu \
+    --block
+```
+
+### Send predictions
+
+```bash
+curl -X POST http://localhost:8000/sentiment \
+  -H "Content-Type: application/json" \
+  -d '{"text": "I love this product!"}'
+
+# Batch (list of records)
+curl -X POST http://localhost:8000/sentiment \
+  -H "Content-Type: application/json" \
+  -d '[{"text": "great"}, {"text": "terrible"}]'
+```
+
+---
+
+## KServe
+
+[KServe](https://kserve.github.io) is the standard for Kubernetes ML inference, implementing
+the Open Inference Protocol v2. Use this for cloud/Kubernetes production deployments.
+
+### Install
+
+```bash
+pip install kserve
+```
+
+### Serve locally
+
+```bash
+python -m ludwig.serve_kserve \
+    --model_name sentiment \
+    --model_path results/experiment_run/model
+```
+
+### Send v2 protocol requests
+
+```bash
+curl -X POST http://localhost:8080/v2/models/sentiment/infer \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputs": [
+      {"name": "text", "shape": [1], "datatype": "BYTES", "data": ["I love this!"]}
+    ]
+  }'
+```
+
+For full deployment examples (autoscaling, A/B testing, Kubernetes manifests) see the
+[Ray Serve and KServe example](../examples/ray_serve.md).
+
+---
+
+## Choosing a serving option
+
+| Option | Scale | Protocol | Best for |
+|--------|-------|----------|----------|
+| `ludwig serve` (FastAPI) | Single process | REST JSON | Development, simple APIs |
+| Ray Serve | Multi-replica, autoscaling | REST JSON | Production on Ray clusters |
+| KServe | Kubernetes-native | OIP v2 | Enterprise Kubernetes |
+| `ludwig serve` (vLLM) | GPU-optimized | OpenAI-compatible | LLM serving |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,8 +42,12 @@ nav:
       - Large Language Models:
           - Large Language Models: user_guide/llms/index.md
           - Fine-Tuning: user_guide/llms/finetuning.md
+          - VLM Fine-Tuning: user_guide/llms/vlm_finetuning.md
+          - Multi-Adapter PEFT: user_guide/llms/multi_adapter.md
           - In-Context Learning: user_guide/llms/in_context_learning.md
           - Text Classification: user_guide/llms/text_classification.md
+          - Structured Output: user_guide/llms/structured_output.md
+          - Config Generation: user_guide/llms/config_generation.md
       - GPUs: user_guide/gpus.md
       - Distributed Training:
           - Distributed Training: user_guide/distributed_training/index.md
@@ -52,6 +56,7 @@ nav:
       - Cloud Storage: user_guide/cloud_storage.md
       - AutoML: user_guide/automl.md
       - Visualizations: user_guide/visualizations.md
+      - Model Inspector: user_guide/model_inspector.md
       - Model Export: user_guide/model_export.md
       - Serving: user_guide/serving.md
       - Third-Party Integrations: user_guide/integrations.md
@@ -96,6 +101,9 @@ nav:
           - Few-shot batch inference for text classification (RAG): examples/llms/llm_few_shot_batch_inference.md
           - Zero-shot batch inference for tabular classification (TabLLM): examples/llms/llm_tabular_zero_shot_batch_inference.md
           - Fine-tuning for tabular classification (TabLLM): examples/llms/llm_tabular_classification.md
+          - VLM Fine-Tuning: examples/vlm_finetuning.md
+          - Multi-Adapter PEFT: examples/multi_adapter.md
+          - LLM Config Generation: examples/config_generation.md
       - Supervised ML:
           - Text Classification: examples/text_classification.md
           - Tabular Data Classification: examples/adult_census_income.md
@@ -119,6 +127,8 @@ nav:
           - Movie rating prediction: examples/movie_ratings.md
           - Multi-label classification: examples/multi_label.md
           - Multi-Task Learning: examples/multi_task.md
+          - HyperNetwork Combiner: examples/hypernetwork.md
+          - Ray Serve and KServe: examples/ray_serve.md
           - Simple Regression - Fuel Efficiency Prediction: examples/fuel_efficiency.md
           - Fraud Detection: examples/fraud.md
   - 🛠️ Developer Guide:


### PR DESCRIPTION
## Summary

Comprehensive documentation update for Ludwig 0.16, covering all major features added since 0.15.

### New user guide pages

- **VLM Fine-Tuning** (`user_guide/llms/vlm_finetuning.md`) — Fine-tune Qwen2-VL, LLaVA, InternVL2 on image+text tasks with QLoRA. Covers dataset format, config, memory requirements, and multi-GPU training.
- **Multi-Adapter PEFT** (`user_guide/llms/multi_adapter.md`) — Train multiple named LoRA adapters and merge with TIES, DARE, or linear combining. Includes strategy comparison table and adapter switching API.
- **LLM Config Generation** (`user_guide/llms/config_generation.md`) — Generate validated Ludwig configs from plain-English task descriptions via Claude/GPT-4o. CLI and Python API.
- **ModelInspector** (`user_guide/model_inspector.md`) — Inspect trained models: weight collection, architecture summary, feature importance proxy.

### New examples (with Colab badge placeholders)

- **VLM Fine-Tuning** (`examples/vlm_finetuning.md`) — End-to-end VQA fine-tuning with dataset prep, config, training, inference, and multi-GPU.
- **HyperNetworkCombiner** (`examples/hypernetwork.md`) — Context-dependent fusion: sensor type generates custom weights for numeric readings. Shows accuracy comparison vs concat.
- **LLM Config Generation** (`examples/config_generation.md`) — From description to trained model in 20 lines of Python.
- **Multi-Adapter PEFT** (`examples/multi_adapter.md`) — Train sentiment + topic adapters separately, merge with TIES.
- **Ray Serve and KServe** (`examples/ray_serve.md`) — Autoscaling deployment, A/B testing, Kubernetes manifests, v2 protocol.

### Updated existing pages

- **`configuration/combiner.md`** — HyperNetworkCombiner section with schema, comparison table, and link to example
- **`user_guide/serving.md`** — Ray Serve and KServe sections with deploy/client snippets and choosing-a-serving-option table
- **`user_guide/llms/index.md`** — Links to VLM, multi-adapter, config generation, and structured output guides
- **`mkdocs.yml`** — Nav entries for all 9 new pages

## Test plan

- [ ] Verify all new pages render in `mkdocs serve`
- [ ] Check Colab badge links once notebooks are created
- [ ] Confirm nav entries appear in correct sections
- [ ] Verify cross-links between pages resolve correctly