### PR TITLE
docs: fill documentation gaps — encoders, combiners, CLI, and new examples

### DIFF
--- a/docs/configuration/combiner.md
+++ b/docs/configuration/combiner.md
@@ -395,6 +395,83 @@ Parameters:
 
 {{ render_fields(schema_class_to_fields(gated_fusion_combiner, exclude=["type"]), details=details) }}
 
+### Project Aggregate Combiner
+
+The `project_aggregate` combiner projects all encoder outputs to the same width, sums them
+element-wise (aggregation), then passes the result through fully connected layers. It is a
+lightweight alternative to `concat` when the number of input features is large, since it avoids
+growing the hidden size linearly with the number of features.
+
+```yaml
+combiner:
+  type: project_aggregate
+  projection_size: 128  # All inputs projected to this width before aggregation
+  output_size: 128      # Output size of FC layers after aggregation
+  num_fc_layers: 2
+  norm: layer           # Normalization applied to projection and FC layers
+  residual: true        # Residual skip connections through FC stack
+  dropout: 0.0
+  activation: relu
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `projection_size` | 128 | Each encoder output is projected to this width before aggregation |
+| `output_size` | 128 | Output size of FC layers after aggregation |
+| `num_fc_layers` | 2 | Number of FC layers after aggregation |
+| `norm` | `layer` | Normalization: `null`, `batch`, `layer` |
+| `residual` | `true` | Add residual skip connections through FC stack |
+| `dropout` | 0.0 | Dropout rate |
+| `activation` | `relu` | Activation function |
+
+{% set project_aggregate_combiner = get_combiner_schema("project_aggregate") %}
+{{ render_yaml(project_aggregate_combiner, parent="combiner") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(project_aggregate_combiner, exclude=["type"]), details=details) }}
+
+### TabPFN v2 Combiner
+
+The `tabpfn_v2` combiner wraps the pretrained [TabPFN v2](https://github.com/PriorLabs/TabPFN)
+foundation model as the ECD fusion block. TabPFN v2 uses in-context learning — it treats the
+training set as context and makes predictions without gradient-based fine-tuning, similar to how
+GPT-4 does few-shot learning.
+
+**When to use**: Small tabular datasets (≤ 10k rows) where gradient-based fine-tuning tends to
+overfit. TabPFN v2 consistently outperforms tuned gradient boosting and neural networks on
+small tabular benchmarks. For large datasets, use `concat`, `ft_transformer`, or `tabnet` instead.
+
+```bash
+pip install tabpfn  # optional dependency
+```
+
+```yaml
+combiner:
+  type: tabpfn_v2
+  output_size: 128      # Width of the learnable projection head on top of TabPFN
+  n_estimators: 4       # Ensemble members (higher = better accuracy, slower inference)
+  device: auto          # auto | cpu | cuda
+```
+
+!!! note
+    TabPFN v2 requires the optional `tabpfn` package. The combiner will raise a clear
+    `ImportError` with install instructions if the package is not found.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `output_size` | 128 | Width of the learnable projection head on top of TabPFN's encoder |
+| `tabpfn_hidden_size` | 512 | TabPFN v2's internal hidden width |
+| `n_estimators` | 4 | Number of ensemble members used during prediction |
+| `device` | `auto` | Device for TabPFN inference: `auto`, `cpu`, `cuda` |
+
+{% set tabpfn_combiner = get_combiner_schema("tabpfn_v2") %}
+{{ render_yaml(tabpfn_combiner, parent="combiner") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(tabpfn_combiner, exclude=["type"]), details=details) }}
+
 ## Common Parameters
 
 These parameters are used across multiple combiners (and some encoders / decoders) in similar ways.

--- a/docs/configuration/features/category_features.md
+++ b/docs/configuration/features/category_features.md
@@ -274,3 +274,62 @@ The measures that are calculated every epoch and are available for category feat
 decoder's confidence) and the `loss` itself.
 You can set either of them as `validation_metric` in the `training` section of the configuration if you set the
 `validation_field` to be the name of a category feature.
+
+---
+
+# Category Distribution Output Feature
+
+`category_distribution` is a specialised output feature type for datasets where each target row is a **soft probability
+distribution over categories** rather than a single hard label.  Typical use cases include:
+
+- Label smoothing targets generated from an ensemble or teacher model
+- Crowd-sourced annotations summarised as empirical agreement rates
+- Reading comprehension tasks with partial-credit labels
+
+The feature type is `category_distribution`.  Because the targets are probability vectors, the column values must be
+parseable as JSON arrays of floats whose length equals the number of classes.
+
+## Configuration
+
+```yaml
+output_features:
+  - name: label_distribution
+    type: category_distribution
+    vocab: [class_a, class_b, class_c]
+    preprocessing:
+      missing_value_strategy: drop_row
+    decoder:
+      type: classifier
+    loss:
+      type: softmax_cross_entropy
+```
+
+### Required parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vocab` | list[str] | Ordered list of class names.  **Required** — `category_distribution` has no way to infer the vocabulary from the soft-label vectors. |
+
+### Preprocessing
+
+{% set preprocessing = get_feature_preprocessing_schema("category_distribution_output") %}
+{{ render_yaml(preprocessing, parent="preprocessing") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(preprocessing), details=details) }}
+
+### Decoders
+
+`category_distribution` reuses the same `classifier` and `mlp_classifier` decoders as the standard `category` output
+feature.  See [Decoders](#decoders) above for parameter details.
+
+### Loss
+
+`category_distribution` targets are treated as probability distributions, so the recommended loss is
+`softmax_cross_entropy` with label smoothing disabled (smoothing is already encoded in the targets).
+
+### Metrics
+
+The same metrics as `category` are reported: `accuracy` (argmax of the predicted distribution vs. argmax of the target
+distribution), `hits_at_k`, and `loss`.

--- a/docs/configuration/features/image_features.md
+++ b/docs/configuration/features/image_features.md
@@ -390,6 +390,117 @@ Parameters:
 
 {{ render_fields(schema_class_to_fields(convnextv2_encoder, exclude=["type"])) }}
 
+### Generic TIMM Encoder
+
+The `timm` encoder exposes the full [pytorch-image-models](https://github.com/huggingface/pytorch-image-models) library
+as a single configurable encoder.  Over 1,000 pretrained vision models are available, including all MetaFormer
+variants, EfficientFormer V2, DaViT, FastViT, and many more.
+
+Install TIMM before using this encoder:
+
+```sh
+pip install timm
+```
+
+```yaml
+encoder:
+  type: timm
+  model_name: caformer_s18.sail_in22k_ft_in1k
+  use_pretrained: true
+  trainable: true
+```
+
+Browse available model names at [timm.fast.ai](https://timm.fast.ai/).
+
+{% set timm_encoder = get_encoder_schema("image", "timm") %}
+{{ render_yaml(timm_encoder, parent="encoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(timm_encoder, exclude=["type"])) }}
+
+### CAFormer Encoder
+
+CAFormer (Yu et al., "MetaFormer Baselines for Vision", TPAMI 2024) is a **hybrid MetaFormer** that uses
+depthwise separable convolutions in the lower stages and self-attention in the upper stages. It achieves
+state-of-the-art accuracy/efficiency trade-offs on ImageNet.
+
+| Variant | Params | ImageNet top-1 |
+|---------|--------|----------------|
+| `caformer_s18` | 26 M | 83.6 % |
+| `caformer_s36` | 39 M | 84.5 % |
+| `caformer_m36` | 56 M | 85.2 % |
+| `caformer_b36` | 99 M | 85.5 % |
+
+```yaml
+encoder:
+  type: caformer
+  model_name: caformer_s18.sail_in22k_ft_in1k
+  use_pretrained: true
+```
+
+{% set caformer_encoder = get_encoder_schema("image", "caformer") %}
+{{ render_yaml(caformer_encoder, parent="encoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(caformer_encoder, exclude=["type"])) }}
+
+### ConvFormer Encoder
+
+ConvFormer replaces the attention token-mixer with a large-kernel depthwise convolution, making it a
+**pure-CNN MetaFormer** that outperforms ConvNeXt while being fully convolutional (no positional embeddings,
+any resolution input).
+
+| Variant | Params | ImageNet top-1 |
+|---------|--------|----------------|
+| `convformer_s18` | 27 M | 83.0 % |
+| `convformer_s36` | 40 M | 84.1 % |
+| `convformer_m36` | 57 M | 84.5 % |
+| `convformer_b36` | 100 M | 84.8 % |
+
+```yaml
+encoder:
+  type: convformer
+  model_name: convformer_s18.sail_in22k_ft_in1k
+  use_pretrained: true
+```
+
+{% set convformer_encoder = get_encoder_schema("image", "convformer") %}
+{{ render_yaml(convformer_encoder, parent="encoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(convformer_encoder, exclude=["type"])) }}
+
+### PoolFormer Encoder
+
+PoolFormer uses simple **average pooling** as the token mixer — proving that the MetaFormer architecture
+itself (not the specific mixer) is responsible for the strong performance of modern vision transformers.
+PoolFormerV2 adds grouped-normalization and extra depth to further close the gap with attention-based models.
+
+| Variant | Params | ImageNet top-1 |
+|---------|--------|----------------|
+| `poolformerv2_s12` | 12 M | 80.3 % |
+| `poolformerv2_s24` | 21 M | 82.0 % |
+| `poolformerv2_s36` | 31 M | 82.7 % |
+| `poolformerv2_m36` | 56 M | 83.5 % |
+| `poolformerv2_m48` | 73 M | 83.8 % |
+
+```yaml
+encoder:
+  type: poolformer
+  model_name: poolformerv2_s12
+  use_pretrained: true
+```
+
+{% set poolformer_encoder = get_encoder_schema("image", "poolformer") %}
+{{ render_yaml(poolformer_encoder, parent="encoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(poolformer_encoder, exclude=["type"])) }}
+
 ### Deprecated Encoders (planned to remove in v0.8)
 
 #### Legacy ResNet Encoder

--- a/docs/configuration/features/sequence_features.md
+++ b/docs/configuration/features/sequence_features.md
@@ -282,6 +282,57 @@ Parameters:
 
 {{ render_fields(schema_class_to_fields(mamba_encoder, exclude=["type"])) }}
 
+### Mamba-2 Encoder
+
+[Mamba-2](https://arxiv.org/abs/2405.21060) (Dao & Gu, 2024) extends Mamba-1 with multi-head
+structured state space duality (SSD). It is faster than Mamba-1 on modern hardware and supports
+a wider range of sequence lengths. Uses pure-PyTorch kernels — no special CUDA installation required.
+
+```yaml
+input_features:
+  - name: seq_feature
+    type: sequence
+    encoder:
+      type: mamba2
+      d_model: 256
+      n_layers: 4
+      num_heads: 8
+      output_size: 256
+      reduce_output: mean
+```
+
+{% set mamba2_seq_encoder = get_encoder_schema("sequence", "mamba2") %}
+{{ render_yaml(mamba2_seq_encoder, parent="encoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(mamba2_seq_encoder, exclude=["type"])) }}
+
+### Jamba Encoder
+
+[Jamba](https://arxiv.org/abs/2403.19887) (Lieber et al., 2024) alternates between Mamba-2 SSM
+blocks and Transformer attention blocks. The ratio is controlled by `attention_every_k`.
+
+```yaml
+input_features:
+  - name: seq_feature
+    type: sequence
+    encoder:
+      type: jamba
+      d_model: 256
+      n_layers: 8
+      attention_every_k: 4
+      output_size: 256
+      reduce_output: mean
+```
+
+{% set jamba_seq_encoder = get_encoder_schema("sequence", "jamba") %}
+{{ render_yaml(jamba_seq_encoder, parent="encoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(jamba_seq_encoder, exclude=["type"])) }}
+
 # Output Features
 
 Sequence output features can be used for either tagging (classifying each element of an input sequence) or

--- a/docs/configuration/features/text_features.md
+++ b/docs/configuration/features/text_features.md
@@ -282,6 +282,74 @@ Parameters:
 
 {{ render_fields(schema_class_to_fields(tfidf_encoder, exclude=["type"])) }}
 
+### Mamba-2 Encoder
+
+[Mamba-2](https://arxiv.org/abs/2405.21060) (Dao & Gu, 2024) is a linear-time selective State
+Space Model (SSM) encoder. It processes sequences in O(L) time instead of O(L²) for attention,
+making it efficient for long texts. Ludwig's Mamba-2 encoder is a pure-PyTorch implementation
+requiring no special CUDA kernels.
+
+**When to use**: Long text sequences (>1k tokens) where Transformer attention becomes a
+bottleneck. Mamba-2 is 2-4× faster than equivalent Transformer encoders on sequences >512 tokens.
+
+```yaml
+input_features:
+  - name: article_text
+    type: text
+    encoder:
+      type: mamba2
+      d_model: 256        # Hidden width of each Mamba-2 block
+      n_layers: 4         # Number of stacked Mamba-2 blocks
+      num_heads: 8        # Number of SSD heads (d_model * expand_factor must be divisible by num_heads)
+      d_conv: 4           # Width of the depthwise 1D convolution
+      expand_factor: 2    # Inner expansion factor
+      output_size: 256    # Output feature width
+      reduce_output: mean # How to reduce the sequence dimension
+```
+
+{% set mamba2_text_encoder = get_encoder_schema("text", "mamba2") %}
+
+{{ render_yaml(mamba2_text_encoder, parent="encoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(mamba2_text_encoder, exclude=["type"])) }}
+
+### Jamba Encoder
+
+[Jamba](https://arxiv.org/abs/2403.19887) (Lieber et al., 2024) is a hybrid encoder that
+interleaves Mamba-2 SSM blocks with Transformer attention blocks. Every `attention_every_k`-th
+layer is a Transformer attention layer; the rest are Mamba-2 SSM layers. This gives better
+stability and accuracy than pure Mamba while retaining much of the efficiency gain.
+
+**When to use**: Long text where you want some of the efficiency of Mamba-2 but better
+accuracy than pure SSM. The 1:3 default attention:SSM ratio is a good starting point.
+
+```yaml
+input_features:
+  - name: article_text
+    type: text
+    encoder:
+      type: jamba
+      d_model: 256
+      n_layers: 8          # Total layers (SSM + attention combined)
+      attention_every_k: 4 # Every 4th layer is attention (1:3 ratio)
+      num_heads: 8
+      ffn_size: 1024       # Feed-forward size inside attention blocks
+      d_conv: 4
+      expand_factor: 2
+      output_size: 256
+      reduce_output: mean
+```
+
+{% set jamba_text_encoder = get_encoder_schema("text", "jamba") %}
+
+{{ render_yaml(jamba_text_encoder, parent="encoder") }}
+
+Parameters:
+
+{{ render_fields(schema_class_to_fields(jamba_text_encoder, exclude=["type"])) }}
+
 ### Huggingface encoders
 
 All huggingface-based text encoders are configured with the following parameters:

--- a/docs/examples/calibration.md
+++ b/docs/examples/calibration.md
@@ -1,0 +1,130 @@
+---
+description: "Calibrate classification model confidence with temperature scaling in Ludwig — config, API, and evaluation examples."
+---
+
+# Probability Calibration
+
+A well-calibrated model produces confidence scores that reflect empirical accuracy: when it says it is 80%
+confident, it should be correct approximately 80% of the time.  Many neural networks are overconfident by default.
+
+Ludwig supports **temperature scaling** (Guo et al., ICML 2017) directly in the decoder config — no
+post-processing step needed.
+
+## What is temperature scaling?
+
+Temperature scaling divides the logits by a learnable scalar *T* before applying softmax:
+
+```
+p = softmax(logits / T)
+```
+
+- *T > 1* softens the distribution (reduces overconfidence).
+- *T < 1* sharpens the distribution (rarely needed).
+- *T = 1* is the uncalibrated model.
+
+Temperature scaling never changes the **argmax** prediction — it only re-shapes the probability distribution.
+The scalar *T* is fit on the validation set after normal training completes.
+
+## Configuration
+
+Add `calibration: temperature_scaling` to the decoder section of any category output feature:
+
+```yaml
+model_type: ecd
+
+input_features:
+  - name: text
+    type: text
+    encoder:
+      type: bert
+      use_pretrained: true
+      trainable: false
+
+output_features:
+  - name: label
+    type: category
+    decoder:
+      type: classifier
+      calibration: temperature_scaling
+
+trainer:
+  epochs: 10
+  optimizer:
+    type: adamw
+    lr: 2.0e-5
+```
+
+Ludwig automatically runs temperature scaling on the validation split at the end of training and serializes *T*
+with the model.  The learned temperature is applied transparently at inference.
+
+## Full pipeline example
+
+```python
+import pandas as pd
+from ludwig.api import LudwigModel
+from sklearn.model_selection import train_test_split
+
+df = pd.read_csv("agnews.csv")
+train_df, test_df = train_test_split(df, test_size=0.2, random_state=42)
+
+model = LudwigModel(config="calibrated_config.yaml", logging_level=1)
+model.train(dataset=train_df, output_directory="results/")
+
+# Predict — returned probabilities are calibrated
+predictions, _ = model.predict(dataset=test_df)
+print(predictions[["label_predictions", "label_probabilities_<CAT>"]])
+```
+
+## Evaluating calibration
+
+Calibration is measured with the **Expected Calibration Error (ECE)**: the weighted average of |accuracy − confidence|
+across probability buckets.  Lower is better; a perfectly calibrated model has ECE = 0.
+
+```python
+import numpy as np
+
+def ece(confidences, labels, n_bins=15):
+    bins = np.linspace(0, 1, n_bins + 1)
+    ece = 0.0
+    for lo, hi in zip(bins[:-1], bins[1:]):
+        mask = (confidences > lo) & (confidences <= hi)
+        if mask.sum() == 0:
+            continue
+        acc = labels[mask].mean()
+        conf = confidences[mask].mean()
+        ece += mask.mean() * abs(acc - conf)
+    return ece
+
+# Extract max probability from Ludwig predictions
+confs = predictions["label_probabilities"].apply(max).values
+labels = (predictions["label_predictions"] == test_df["label"].values).astype(float)
+print(f"ECE: {ece(confs, labels):.4f}")
+```
+
+## Monte Carlo dropout uncertainty
+
+For an alternative uncertainty estimate that does not require a validation set, use MC dropout:
+
+```yaml
+output_features:
+  - name: label
+    type: category
+    decoder:
+      type: mlp_classifier
+      num_fc_layers: 2
+      dropout: 0.2
+      mc_dropout_samples: 20
+```
+
+With `mc_dropout_samples > 0`, Ludwig runs the decoder 20 times at inference with dropout active and returns
+the **mean** prediction and an **uncertainty** tensor capturing variance across samples.
+
+## When to calibrate
+
+- **Safety-critical applications** where predicted confidence is acted upon (medical, finance, autonomous systems).
+- **Threshold-based classifiers** where a specific confidence level triggers an action.
+- **Ensembles and distillation** — calibrated soft targets improve student model quality.
+- **Retrieval and ranking** — calibrated scores enable meaningful score comparison across classes.
+
+Temperature scaling is lightweight and almost always improves calibration without hurting accuracy, so it is
+recommended as a default for production classification models.

--- a/docs/examples/kfold_cv.md
+++ b/docs/examples/kfold_cv.md
@@ -1,0 +1,143 @@
+---
+description: "K-fold cross-validation with Ludwig — run repeated stratified splits for reliable model evaluation."
+---
+
+# K-Fold Cross-Validation
+
+K-fold cross-validation gives a more reliable performance estimate than a single train/val/test split,
+especially for small datasets.  Ludwig supports k-fold CV through the Python API.
+
+## How it works
+
+1. The dataset is split into *k* non-overlapping folds.
+2. For each fold *i*, the model is trained on the remaining *k − 1* folds and evaluated on fold *i*.
+3. Final metrics are averaged across all *k* folds.
+
+## Example: binary classification on Titanic
+
+```python
+import pandas as pd
+from sklearn.model_selection import StratifiedKFold
+from ludwig.api import LudwigModel
+import numpy as np
+
+config = {
+    "model_type": "ecd",
+    "input_features": [
+        {"name": "Pclass", "type": "category"},
+        {"name": "Sex", "type": "category"},
+        {"name": "Age", "type": "number", "preprocessing": {"missing_value_strategy": "fill_with_mean"}},
+        {"name": "SibSp", "type": "number"},
+        {"name": "Fare", "type": "number"},
+    ],
+    "output_features": [
+        {"name": "Survived", "type": "binary"}
+    ],
+    "trainer": {"epochs": 20},
+}
+
+df = pd.read_csv("titanic.csv")
+skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+
+fold_metrics = []
+for fold, (train_idx, val_idx) in enumerate(skf.split(df, df["Survived"])):
+    train_df = df.iloc[train_idx]
+    val_df = df.iloc[val_idx]
+
+    model = LudwigModel(config=config, logging_level=0)
+    model.train(
+        training_set=train_df,
+        validation_set=val_df,
+        output_directory=f"results/fold_{fold}",
+    )
+    eval_stats, _, _ = model.evaluate(dataset=val_df)
+    fold_metrics.append(eval_stats["Survived"]["accuracy"])
+    print(f"Fold {fold+1} accuracy: {fold_metrics[-1]:.4f}")
+
+print(f"\nMean accuracy: {np.mean(fold_metrics):.4f} ± {np.std(fold_metrics):.4f}")
+```
+
+## Stratified splitting for classification
+
+For classification tasks with imbalanced classes, always use stratified k-fold to ensure each fold contains
+approximately the same proportion of each class.  The `StratifiedKFold` example above does this automatically.
+
+## Repeated k-fold
+
+For very small datasets (< 200 rows), repeated k-fold further reduces variance by running k-fold multiple times
+with different random seeds:
+
+```python
+from sklearn.model_selection import RepeatedStratifiedKFold
+
+rskf = RepeatedStratifiedKFold(n_splits=5, n_repeats=3, random_state=42)
+# Use rskf.split() in place of skf.split() in the loop above
+```
+
+## Group k-fold
+
+Use group k-fold when samples have a grouping structure that must not be split across folds (e.g., multiple
+readings from the same patient, or multiple images from the same object):
+
+```python
+from sklearn.model_selection import GroupKFold
+
+gkf = GroupKFold(n_splits=5)
+groups = df["patient_id"]  # ensure no patient appears in both train and val
+
+for fold, (train_idx, val_idx) in enumerate(gkf.split(df, df["label"], groups)):
+    ...
+```
+
+## Time-series split
+
+For time series data, never shuffle — use a rolling-window split to preserve temporal order:
+
+```python
+from sklearn.model_selection import TimeSeriesSplit
+
+tscv = TimeSeriesSplit(n_splits=5)
+df_sorted = df.sort_values("timestamp")
+
+for fold, (train_idx, val_idx) in enumerate(tscv.split(df_sorted)):
+    ...
+```
+
+## Aggregating results
+
+```python
+import numpy as np
+
+# After collecting fold_metrics list:
+mean = np.mean(fold_metrics)
+std = np.std(fold_metrics)
+ci_95 = 1.96 * std / np.sqrt(len(fold_metrics))  # 95% confidence interval
+
+print(f"Accuracy: {mean:.4f} ± {ci_95:.4f} (95% CI)")
+```
+
+## Distributed k-fold with Ray
+
+Running each fold in parallel on a Ray cluster reduces wall-clock time linearly with the number of available workers:
+
+```python
+import ray
+from ludwig.backend import RAY
+
+ray.init()
+
+config["backend"] = {"type": "ray", "trainer": {"num_workers": 4}}
+# Then run the same loop — Ludwig will distribute each fold across 4 GPU workers
+```
+
+## When to use k-fold
+
+| Dataset size | Recommendation |
+|-------------|----------------|
+| < 500 rows | 10-fold or repeated 5-fold |
+| 500–5k rows | 5-fold |
+| 5k–50k rows | Holdout split is usually sufficient; 5-fold if you need tight confidence intervals |
+| > 50k rows | Single holdout split — k-fold provides minimal additional benefit |
+
+For hyperparameter search, prefer a single train/val/test split (or nested k-fold) over running hyperopt inside
+each k-fold, as the computational cost grows as *k × number of trials*.

--- a/docs/examples/optimizer_comparison.md
+++ b/docs/examples/optimizer_comparison.md
@@ -1,0 +1,128 @@
+---
+description: "Compare optimizers (Adam, AdamW, Lion, Sophia) for Ludwig model training — configuration examples and practical guidance."
+---
+
+# Optimizer Comparison
+
+Choosing the right optimizer can meaningfully affect convergence speed and final accuracy.
+Ludwig exposes all major optimizers through the `trainer.optimizer` config block.
+
+## Supported optimizers
+
+| Optimizer | Key strength | Typical use case |
+|-----------|-------------|-----------------|
+| `sgd` | Baseline, well-understood | Small tabular models |
+| `adam` | Fast convergence, adaptive LR | Default for most tasks |
+| `adamw` | Adam + decoupled weight decay | Fine-tuning pretrained models |
+| `rmsprop` | Stable for RNNs | Sequence models |
+| `lion` | Memory-efficient (no second moment) | Large models on limited memory |
+| `sophia` | Second-order curvature estimate | Transformers, NLP tasks |
+
+## Configurations
+
+### Adam (default)
+
+```yaml
+trainer:
+  optimizer:
+    type: adam
+    lr: 1.0e-3
+    betas:
+      - 0.9
+      - 0.999
+    eps: 1.0e-8
+```
+
+### AdamW
+
+AdamW decouples weight decay from the gradient update, which prevents weight decay from inadvertently acting as
+an adaptive learning rate dampener.  Use it whenever training from scratch with regularisation or when fine-tuning.
+
+```yaml
+trainer:
+  optimizer:
+    type: adamw
+    lr: 3.0e-4
+    weight_decay: 0.01
+```
+
+### Lion
+
+[Lion](https://arxiv.org/abs/2302.06675) (EvoLved Sign Momentum) uses only the sign of the gradient update,
+requiring no second moment accumulator.  This halves optimizer memory usage vs. Adam/AdamW — a major advantage
+when training large models.  Lion typically works best with a learning rate 3–10× smaller than AdamW.
+
+```yaml
+trainer:
+  optimizer:
+    type: lion
+    lr: 3.0e-5
+    weight_decay: 0.1
+    betas:
+      - 0.9
+      - 0.99
+```
+
+### Sophia
+
+[Sophia](https://arxiv.org/abs/2305.14342) estimates the diagonal Hessian of the loss using a Hutchinson estimator
+and uses it to precondition the gradient step.  This can accelerate training of transformer-based models by 2× over
+AdamW on NLP benchmarks.
+
+```yaml
+trainer:
+  optimizer:
+    type: sophia
+    lr: 2.0e-4
+    betas:
+      - 0.965
+      - 0.99
+    rho: 0.04
+    weight_decay: 0.1
+    update_period: 10     # how often to re-estimate the Hessian
+```
+
+## Learning rate schedulers
+
+Optimizers are paired with learning rate schedulers.  The most commonly used are:
+
+```yaml
+trainer:
+  learning_rate_scheduler:
+    type: cosine          # cosine annealing — good default for fine-tuning
+    # type: reduce_on_plateau  # reduce LR when val loss stagnates
+    # type: linear_warmup   # warmup then constant — good for transformers
+    warmup_fraction: 0.1  # fraction of training steps used for warm-up
+```
+
+## Hyperopt search
+
+Use Ludwig's hyperopt to find the best optimizer and learning rate automatically:
+
+```yaml
+hyperopt:
+  search_alg: hyperband
+  goal: minimize
+  metric: validation_loss
+  parameters:
+    trainer.optimizer.type:
+      type: category
+      values: [adam, adamw, lion]
+    trainer.optimizer.lr:
+      type: float
+      low: 1.0e-5
+      high: 1.0e-2
+      scale: log
+    trainer.optimizer.weight_decay:
+      type: float
+      low: 0.0
+      high: 0.1
+```
+
+## Practical guidance
+
+- **Start with AdamW** for fine-tuning tasks and Adam for training from scratch.
+- **Switch to Lion** if GPU memory is tight and you cannot reduce batch size further.
+- **Try Sophia** for transformer encoders in NLP tasks when training time matters.
+- **Learning rate is the most important hyperparameter** — always tune it first regardless of optimizer.
+- **Warm-up** (5–10 % of total steps) is important for all adaptive optimizers when training transformers.

--- a/docs/examples/semantic_segmentation.md
+++ b/docs/examples/semantic_segmentation.md
@@ -1,0 +1,127 @@
+---
+description: "Train a semantic segmentation model with Ludwig using a U-Net or SegFormer decoder on a pixel-level labeling task."
+---
+
+# Semantic Segmentation
+
+Semantic segmentation assigns a class label to every pixel in an image.
+Ludwig supports segmentation natively through image output features with `U-Net` and `SegFormer` decoders.
+
+## Dataset
+
+We use the [Oxford-IIIT Pet Dataset](https://www.robots.ox.ac.uk/~vgg/data/pets/) where each image has a corresponding
+trimap mask (foreground / background / uncertain). The CSV has two columns:
+
+| image | mask |
+|-------|------|
+| images/Abyssinian_1.jpg | masks/Abyssinian_1.png |
+| ... | ... |
+
+## Config
+
+```yaml
+model_type: ecd
+
+input_features:
+  - name: image
+    type: image
+    encoder:
+      type: convnextv2            # hierarchical CNN pretrained on ImageNet-22k
+      model_name: convnextv2_tiny
+      use_pretrained: true
+      trainable: true
+
+output_features:
+  - name: mask
+    type: image
+    decoder:
+      type: unet
+      num_classes: 3              # foreground / background / uncertain
+    loss:
+      type: softmax_cross_entropy
+
+preprocessing:
+  image:
+    height: 256
+    width: 256
+    num_channels: 3
+
+trainer:
+  epochs: 30
+  batch_size: 16
+  optimizer:
+    type: adamw
+    lr: 3.0e-4
+  learning_rate_scheduler:
+    type: cosine
+  use_mixed_precision: true
+```
+
+## Training
+
+```python
+import ludwig
+from ludwig.api import LudwigModel
+
+model = LudwigModel(config="segmentation_config.yaml", logging_level=1)
+results = model.train(dataset="pets_segmentation.csv", output_directory="results")
+```
+
+## Switching to SegFormer
+
+[SegFormer](https://arxiv.org/abs/2105.15203) pairs a hierarchical Mix-Transformer (MiT) encoder with a
+lightweight MLP decoder and achieves better accuracy than U-Net with fewer parameters.
+
+```yaml
+input_features:
+  - name: image
+    type: image
+    encoder:
+      type: vit                   # or swin for hierarchical features
+      use_pretrained: true
+
+output_features:
+  - name: mask
+    type: image
+    decoder:
+      type: segformer
+      num_classes: 3
+      hidden_dim: 256
+```
+
+## Feature Pyramid Network decoder
+
+FPN decoders combine multi-scale features from the encoder backbone and produce high-resolution outputs without
+requiring a symmetric up-sampling path, which reduces memory usage compared to U-Net for large images.
+
+```yaml
+output_features:
+  - name: mask
+    type: image
+    decoder:
+      type: fpn
+      num_classes: 3
+      num_channels: 128
+      upsample_mode: bilinear
+```
+
+## Evaluation
+
+Ludwig reports per-class pixel accuracy and mean IoU (intersection over union) automatically for segmentation tasks.
+
+```python
+eval_stats, predictions, output_dir = model.evaluate(
+    dataset="pets_test.csv",
+    collect_predictions=True,
+    output_directory="eval_results",
+)
+print(eval_stats["mask"]["mean_iou"])
+```
+
+## Tips
+
+- **Input resolution**: U-Net and SegFormer both benefit from images ≥ 256×256.  At 512×512 or larger, reduce
+  `batch_size` and enable `use_mixed_precision: true`.
+- **Encoder choice**: `convnextv2` and `swin` produce hierarchical features that work best with FPN/SegFormer.
+  Plain `vit` works better with U-Net.
+- **Class imbalance**: For highly imbalanced classes (e.g., thin boundaries), add `class_weights` to the loss.

--- a/docs/user_guide/command_line_interface.md
+++ b/docs/user_guide/command_line_interface.md
@@ -21,6 +21,12 @@ Ludwig provides several functions through its command line interface.
 | [`preprocess`](#preprocess)                   | Preprocess data and saves it into cached format                                   |
 | [`synthesize_dataset`](#synthesize_dataset)   | Creates synthetic data for testing purposes                                       |
 | [`upload_to_hf_hub`](#upload_to_hf_hub)       | Push trained model artifacts to HuggingFace Hub                                   |
+| [`forecast`](#forecast)                       | Forecast future values in a time series using a pretrained model                  |
+| [`benchmark`](#benchmark)                     | Run experiments on a set of datasets and configs and export artifacts             |
+| [`datasets`](#datasets)                       | Download and list Ludwig-ready datasets from the dataset zoo                      |
+| [`generate_config`](#generate_config)         | Generate a Ludwig config from a natural language task description using an LLM    |
+| [`export_schema`](#export_schema)             | Export the Ludwig config JSON schema                                              |
+| [`check_install`](#check_install)             | Verify that Ludwig is correctly installed by running a quick synthetic training   |
 
 These are described in detail below.
 
@@ -1219,3 +1225,247 @@ ludwig upload hf_hub --repo_id ludwig/test_model --model_path ~/trained_models/m
 ```
 
 This will upload the fine-tuned weights in ` ~/trained_models/my_model` to `ludwig/test_model` on HuggingFace Hub.
+
+# forecast
+
+Load a pretrained Ludwig time series model and forecast the next `n` data points beyond the end of the dataset.
+
+```
+ludwig forecast [options]
+```
+
+These are the available arguments:
+
+```
+usage: ludwig forecast [options]
+
+This script loads a pretrained model and uses it to forecast
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -n HORIZON, --horizon HORIZON
+                        horizon, or number of steps in the future to forecast (default: 1)
+  --dataset DATASET     input data file path
+  --data_format {auto,csv,excel,feather,fwf,hdf5,html,tables,json,jsonl,parquet,pickle,sas,spss,stata,tsv}
+                        format of the input data
+  -m MODEL_PATH, --model_path MODEL_PATH
+                        model to load
+  -od OUTPUT_DIRECTORY, --output_directory OUTPUT_DIRECTORY
+                        directory that contains the results (default: results)
+  -of {csv,parquet}, --output_format {csv,parquet}
+                        format to write the output dataset (default: parquet)
+  -b {local,ray}, --backend {local,ray}
+                        specifies backend to use for parallel / distributed execution
+  -l {critical,error,warning,info,debug,notset}, --logging_level {critical,error,warning,info,debug,notset}
+                        the level of logging to use
+```
+
+Example:
+
+```sh
+ludwig forecast \
+  --dataset weather.csv \
+  --model_path results/experiment_run/model \
+  --horizon 7 \
+  --output_directory forecasts
+```
+
+# benchmark
+
+Run Ludwig experiments on a collection of datasets and configs, tracking performance and exporting artifacts.
+This is useful for comparing model configurations or measuring regression across Ludwig versions.
+
+```
+ludwig benchmark [options]
+```
+
+These are the available arguments:
+
+```
+usage: ludwig benchmark [options]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --benchmarking_config BENCHMARKING_CONFIG
+                        path to the benchmarking config YAML file
+```
+
+The benchmarking config is a YAML file that specifies which datasets to run on and which Ludwig configs to use.
+Example benchmarking config:
+
+```yaml
+export_artifacts: true
+output_directory: benchmark_results
+experiments:
+  - dataset: adult_census_income
+    config_path: configs/adult_baseline.yaml
+  - dataset: titanic
+    config_path: configs/titanic_baseline.yaml
+```
+
+Example:
+
+```sh
+ludwig benchmark --benchmarking_config my_benchmark.yaml
+```
+
+# datasets
+
+Download and list Ludwig-ready datasets from the built-in [dataset zoo](../datasets/dataset_zoo.md).
+
+```
+ludwig datasets <command> [options]
+```
+
+Subcommands:
+
+| Subcommand  | Description                              |
+|-------------|------------------------------------------|
+| `list`      | List all available datasets              |
+| `describe`  | Print description and metadata for a dataset |
+| `download`  | Download a dataset to a local directory  |
+
+```
+usage: ludwig datasets [options]
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+subcommands:
+  list                  list datasets
+  download DATASET [-o OUTPUT_DIR]
+                        download a dataset to OUTPUT_DIR (default: .)
+  describe DATASET      describe a dataset
+```
+
+Examples:
+
+```sh
+# List all datasets
+ludwig datasets list
+
+# Download the Titanic dataset to ./data
+ludwig datasets download titanic -o data/
+
+# Describe the adult_census_income dataset
+ludwig datasets describe adult_census_income
+```
+
+# generate_config
+
+Generate a Ludwig YAML configuration from a plain-English description of the ML task using an LLM (Claude or GPT-4).
+
+```
+ludwig generate_config [options] "description"
+```
+
+These are the available arguments:
+
+```
+usage: ludwig generate_config [options]
+
+Generate a Ludwig config from a natural language task description
+
+positional arguments:
+  description           Natural language description of the ML task
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --model MODEL         LLM model to use (default: claude-sonnet-4-20250514)
+  --api_key API_KEY     API key for the LLM provider (reads from ANTHROPIC_API_KEY or OPENAI_API_KEY by default)
+  -o OUTPUT, --output OUTPUT
+                        Output file path. Prints to stdout if not specified.
+  --no-validate         Skip config validation
+```
+
+The command reads an `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` environment variable unless `--api_key` is provided.
+If no description argument is given, it reads from stdin.
+
+Examples:
+
+```sh
+# Print generated config to stdout
+ludwig generate_config "Predict house prices from square footage, location, and number of bedrooms"
+
+# Save to a file and then train
+ludwig generate_config \
+  "Classify customer reviews as positive or negative" \
+  -o my_config.yaml
+
+ludwig train --config my_config.yaml --dataset reviews.csv
+```
+
+# export_schema
+
+Export the Ludwig config JSON schema to a file or stdout.  The schema can be used with IDE plugins, `jsonschema`
+validators, or OpenAPI tooling to validate Ludwig config files programmatically.
+
+```
+ludwig export_schema [options]
+```
+
+These are the available arguments:
+
+```
+usage: ludwig export_schema [options]
+
+Export Ludwig config JSON schema
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --model-type {ecd,llm,combined}
+                        model type to export schema for (default: combined)
+  -o OUTPUT, --output OUTPUT
+                        output file (default: stdout)
+  --full                include parameter_metadata in the output (stripped by default)
+```
+
+Examples:
+
+```sh
+# Export combined ECD + LLM schema to a file
+ludwig export_schema -o ludwig_schema.json
+
+# Export only the LLM model schema
+ludwig export_schema --model-type llm -o llm_schema.json
+
+# Validate a config against the schema using Python
+python -c "
+import json, jsonschema, yaml
+schema = json.load(open('ludwig_schema.json'))
+config = yaml.safe_load(open('my_config.yaml'))
+jsonschema.validate(config, schema)
+print('Config is valid')
+"
+```
+
+# check_install
+
+Verify that Ludwig is correctly installed by running a short training run on synthetic data.
+This is useful after installation or when debugging environment issues.
+
+```
+ludwig check_install [options]
+```
+
+These are the available arguments:
+
+```
+usage: ludwig check_install [options]
+
+This command checks Ludwig installation on a synthetic dataset.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -l {critical,error,warning,info,debug,notset}, --logging_level {critical,error,warning,info,debug,notset}
+                        the level of logging to use (default: warning)
+```
+
+Example:
+
+```sh
+ludwig check_install
+```
+
+If Ludwig is correctly installed the command exits with code `0` and prints a success message.
+Any missing dependency or CUDA misconfiguration will surface as an error here before you run a real job.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,11 @@ nav:
           - Multi-Task Learning: examples/multi_task.md
           - Simple Regression - Fuel Efficiency Prediction: examples/fuel_efficiency.md
           - Fraud Detection: examples/fraud.md
+          - Semantic Segmentation: examples/semantic_segmentation.md
+      - Guides:
+          - Optimizer Comparison: examples/optimizer_comparison.md
+          - Probability Calibration: examples/calibration.md
+          - K-Fold Cross-Validation: examples/kfold_cv.md
   - 🛠️ Developer Guide:
       - Developer Guide: developer_guide/index.md
       - How to Contribute: developer_guide/contributing.md


### PR DESCRIPTION
## Summary

- **Encoders**: Added Mamba-2 and Jamba encoder sections to `text_features.md` and `sequence_features.md`; added CAFormer, ConvFormer, PoolFormer, and generic TIMM encoder sections to `image_features.md`
- **Combiners**: Added ProjectAggregate and TabPFNV2 combiner sections to `combiner.md`
- **Features**: Added `category_distribution` output feature section to `category_features.md`
- **CLI**: Documented six previously undocumented commands — `forecast`, `benchmark`, `datasets`, `generate_config`, `export_schema`, `check_install` — including argument tables and examples
- **Examples**: Four new example pages — semantic segmentation, optimizer comparison, probability calibration (temperature scaling), and k-fold cross-validation

## Test plan

- [ ] All existing mkdocs macro calls use correct schema names (`get_encoder_schema`, `get_combiner_schema`, `get_feature_preprocessing_schema`)
- [ ] New nav entries in `mkdocs.yml` match actual file paths
- [ ] CLI argument tables match `--help` output in the source files
- [ ] Example configs use valid Ludwig feature types and parameter names